### PR TITLE
fix(install): build-bundle third-party 約束修正 + topology 測試自足

### DIFF
--- a/changelog.d/fix-build-bundle-thirdparty-constraint.md
+++ b/changelog.d/fix-build-bundle-thirdparty-constraint.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: install
+---
+build-bundle.sh 的 third-party 依賴改為依已下載的 first-party wheel（core + 選定 plugins + serialwrap）metadata 解析閉包，取代原本手列套件名裸抓最新版——後者會抓到違反 core `click>=8.1,<8.4` pin 的 click 8.4.x，使 dry-run gate 以 ResolutionImpossible 失敗、產不出 bundle。新增 regression 測試鎖定此契約。

--- a/changelog.d/fix-topology-tests-self-contained.md
+++ b/changelog.d/fix-topology-tests-self-contained.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: test
+---
+test_topology.py 改用 pytest fixture 於 tmp_path 寫入最小 testbed.yaml，不再依賴 git-ignored 的 configs/testbed.yaml（原本僅 CI bootstrap step 會產生），fresh clone 直接 pytest 不再有 2 個 failure。四項斷言不變（name=lab-bench-1、DUT 裝置、SSID_5G→testpilot5G、未知變數原樣保留）；inline testbed 僅含 name/DUT/SSID 不含任何 KEY 憑證，維持 R-21 機密掃描潔淨。

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -327,11 +327,18 @@ if [[ -n "$SERIALWRAP_REPO" && -n "$SERIALWRAP_VERSION" ]]; then
 fi
 
 # ── Download third-party deps (binary only, for current platform) ─────────────
-# The closure is resolved for the active platform and python version.
-# Known direct dependencies of testpilot-core; transitive deps resolved by pip.
-THIRD_PARTY_DEPS="pyyaml click rich openpyxl ruamel.yaml"
-info "Downloading third-party deps (binary only): ${THIRD_PARTY_DEPS}"
-pip download --only-binary=:all: --dest "$WHEELHOUSE" $THIRD_PARTY_DEPS \
+# Resolve the third-party closure FROM the already-downloaded first-party wheels
+# (core + selected plugins + serialwrap) so pip honors THEIR pinned constraints.
+# Enumerating dep names by hand instead grabbed the latest of each — e.g. click
+# 8.4.x, which violates core's `click>=8.1,<8.4` and fails the dry-run gate.
+# --find-links lets the first-party wheels satisfy each other locally (they are
+# not on any public index) while transitive third-party deps resolve normally.
+info "Downloading third-party deps (binary only), resolved against first-party wheel metadata ..."
+mapfile -t FIRST_PARTY_WHEELS < <(ls "$WHEELHOUSE"/*.whl 2>/dev/null)
+[[ "${#FIRST_PARTY_WHEELS[@]}" -gt 0 ]] || fail "No first-party wheels in wheelhouse to resolve deps against."
+pip download --only-binary=:all: --dest "$WHEELHOUSE" \
+    --find-links "$WHEELHOUSE" \
+    "${FIRST_PARTY_WHEELS[@]}" \
     || warn "Some third-party deps could not be downloaded as binary wheels (may need to build from source on target)"
 
 # ── Generate pinned requirements.txt ─────────────────────────────────────────

--- a/tests/test_build_bundle_sh.py
+++ b/tests/test_build_bundle_sh.py
@@ -55,3 +55,16 @@ def test_downloads_release_wheels_not_rebuild():
 
 def test_pins_requirements():
     assert "requirements.txt" in SH
+
+
+def test_third_party_deps_resolved_from_first_party_wheels():
+    # Regression guard for the click>=8.1,<8.4 breakage: third-party deps must be
+    # resolved FROM the already-downloaded first-party wheels' metadata (so core's
+    # pins are honored), NOT hand-listed as bare package names — which grabbed the
+    # latest click (8.4.x), violated core's pin, and failed the dry-run gate.
+    assert "FIRST_PARTY_WHEELS" in SH, (
+        "third-party deps must resolve against the first-party wheels' metadata"
+    )
+    assert "THIRD_PARTY_DEPS=" not in SH, (
+        "third-party deps must not be hand-enumerated as bare package names"
+    )

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,26 +1,50 @@
-"""Test TestbedConfig loading and variable resolution."""
+"""Test TestbedConfig loading and variable resolution.
 
+These tests supply their own minimal testbed via a tmp_path fixture instead of
+reading the git-ignored ``configs/testbed.yaml`` (which only CI's bootstrap step
+materializes), so a fresh clone ``pytest`` is green. The inline testbed is
+deliberately credential-free (name + one device + one SSID variable only) to
+keep the R-21 secret scan clean.
+"""
+
+import textwrap
 from pathlib import Path
+
+import pytest
 
 from testpilot.core.testbed_config import TestbedConfig
 
+# Minimal, credential-free testbed matching the CI bootstrap shape.
+_MINIMAL_TESTBED = textwrap.dedent(
+    """\
+    testbed:
+      name: lab-bench-1
+      devices:
+        DUT:
+          role: ap
+          transport: serial
+          selector: COM0
+      variables:
+        SSID_5G: testpilot5G
+    """
+)
 
-def test_load_config():
-    root = Path(__file__).resolve().parents[1]
-    cfg = TestbedConfig(root / "configs" / "testbed.yaml")
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> TestbedConfig:
+    path = tmp_path / "testbed.yaml"
+    path.write_text(_MINIMAL_TESTBED, encoding="utf-8")
+    return TestbedConfig(path)
+
+
+def test_load_config(cfg: TestbedConfig) -> None:
     assert cfg.name == "lab-bench-1"
     assert "DUT" in cfg.devices
 
 
-def test_variable_resolve():
-    root = Path(__file__).resolve().parents[1]
-    cfg = TestbedConfig(root / "configs" / "testbed.yaml")
-    result = cfg.resolve("SSID is {{SSID_5G}}")
-    assert "testpilot5G" in result
+def test_variable_resolve(cfg: TestbedConfig) -> None:
+    assert "testpilot5G" in cfg.resolve("SSID is {{SSID_5G}}")
 
 
-def test_missing_variable():
-    root = Path(__file__).resolve().parents[1]
-    cfg = TestbedConfig(root / "configs" / "testbed.yaml")
-    result = cfg.resolve("{{NONEXIST}}")
-    assert "{{NONEXIST}}" in result
+def test_missing_variable(cfg: TestbedConfig) -> None:
+    assert "{{NONEXIST}}" in cfg.resolve("{{NONEXIST}}")


### PR DESCRIPTION
## Summary

離線部署演練（testpilot-core + wifi_llapi 離線 bundle）過程中發現並修復的兩個 bug。

### build-bundle.sh third-party 相依未受 core 約束（離線 build gate 失敗）
`build-bundle.sh` 的 third-party 相依原本手列套件名裸抓最新版，會抓到 `click 8.4.x`，違反 core `pyproject` 的 `click>=8.1,<8.4` pin，使離線 build 的 dry-run gate 以 ResolutionImpossible 失敗、產不出 bundle。改為**依已下載的 first-party wheel（core + 選定 plugins + serialwrap）metadata 解析 third-party 閉包**，honuor 其 pin，未來 core 改相依也自動跟上。新增 regression 測試 `test_third_party_deps_resolved_from_first_party_wheels`。

### test_topology.py 依賴 CI-only testbed（fresh clone 測試失敗）
3 個測試硬讀 git-ignored 的 `configs/testbed.yaml`（僅 CI 的 bootstrap step 產生），fresh clone `pytest` 有 2 個 failure。改用 pytest `tmp_path` fixture 寫最小、**credential-free**（避開 R-21 機密掃描）的 testbed.yaml；四項斷言不變。

## Validation
- `pytest` 全套 **552 passed**（含新 regression；原本此環境會 2 failed）
- 離線 build 不再需要任何繞過即可產出 bundle（click 自動解成相容 8.3.3）
- **codex `/codex:adversarial-review`：verdict approve，無 material findings**

## Release Notes Impact
- Type: fix
- Changelog: `changelog.d/` fragments ×2（type: fix）
- Docs impact: 無
- CLI help sync: n/a（未改 CLI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)