### PR TITLE
fix(install): install-manifest core.private 更正為 false（對齊 public repo）

### DIFF
--- a/changelog.d/fix-manifest-core-public.md
+++ b/changelog.d/fix-manifest-core-public.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: install
+---
+install-manifest.yaml 的 `core.private` 由 `true` 更正為 `false`，對齊 `hamanpaul/testpilot-core` 實際為 public repo（serialwrap 亦 public 且標記正確；wifi_llapi/brcm_fw_upgrade 維持 private）。此欄位為 registry 標記、install.sh/build-bundle.sh 皆未讀取，故無行為變更，僅修正誤導的 metadata。

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -6,7 +6,7 @@
 core:
   distribution: testpilot-core
   repo: hamanpaul/testpilot-core
-  private: true
+  private: false             # public repo
 plugins:
   - name: wifi_llapi
     repo: hamanpaul/wifi_llapi


### PR DESCRIPTION
## Summary

`install-manifest.yaml` 的 `core.private` 由 `true` 更正為 `false`，對齊 `hamanpaul/testpilot-core` 實際為 **public** repo。

（serialwrap 亦 public 且原標記 `false` 正確；wifi_llapi / brcm_fw_upgrade 維持 `private: true`，實際亦為 private。）

## 無行為變更
`private` 欄位為 registry 標記，`scripts/install.sh` 與 `scripts/build-bundle.sh` **皆未讀取**（已 grep 確認），故此更正純為修正誤導的 metadata，不影響線上/離線安裝或 bundle build。

## Validation
- `pytest tests/test_install_manifest.py tests/test_install_compat.py` → **10 passed**
- `testpilot install-doctor --manifest install-manifest.yaml` → **manifest compatible**

## Release Notes Impact
- Type: fix / scope: install
- Changelog: `changelog.d/` fragment
- Docs impact: 無 ｜ CLI help sync: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)