### PR TITLE
fix(copilot_session): 對齊 github-copilot-sdk 0.1.x permission handler (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ preparation.
 ### Added
 - 可運行的最小 sample plugin `examples/sample_echo`(獨立 dist `testpilot-sample-echo`,經 `testpilot.plugins` entry-point 被發現、僅依賴 `testpilot.api`、`create_runner`→`run_pipeline` 產出 Pass verdict,含 `register_cli` demo);CI 加真實安裝發現 smoke;dev-guide/README 指向 sample 並修死連結、清 `plugins/wifi_llapi/reports/` 並加 `.gitignore` 防 `plugins/*/reports/` run bundle 再被追蹤(保留 `templates/`;R-21)。對照 #3。
 
+### Fixed
+- copilot session foundation 對齊 github-copilot-sdk 0.1.x（`PermissionHandler.approve_all` 已不存在）：自組 approve-all permission handler（wire shape `{"kind": "approved"}`）；session 建立失敗改為一次性 loud warning + run payload `agent_session_degraded` key，終結 silent builtin-fallback（#16）
+
 ## [0.3.3] - 2026-07-04
 
 ### Added

--- a/changelog.d/fix-copilot-sdk-permission.md
+++ b/changelog.d/fix-copilot-sdk-permission.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: core
+---
+copilot session foundation 對齊 `github-copilot-sdk` 0.1.x：實裝的 0.1.23 `PermissionHandler` 是 typing alias（非帶 `approve_all` 的 class），使每次 session 建立必然 raise → remediation silent 降級 builtin-fallback。改為 feature-detect `PermissionRequestResult` 自組 approve-all handler（wire shape `{"kind": "approved"}`，測試鎖形狀防 false-green），移除舊 `approve_all` 雙軌；session 建立失敗改一次性 loud warning + `run_loop` payload `agent_session_degraded` key（run-scoped，`run()` 入口重置）。(#16)

--- a/docs/superpowers/plans/2026-07-06-copilot-sdk-permission-alignment.md
+++ b/docs/superpowers/plans/2026-07-06-copilot-sdk-permission-alignment.md
@@ -1,0 +1,279 @@
+# copilot SDK 0.1.x Permission Handler 對齊 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** session foundation 在 github-copilot-sdk 0.1.x 下可成功建立（approve-all wire shape `{"kind": "approved"}`），建立失敗時 loud surfacing（一次性 warning + run payload degraded key）。
+
+**Architecture:** 只動三處——`copilot_session.py::_resolve_permission_handler`（自組 callable、feature-detect `PermissionRequestResult`）、`orchestrator._create_case_session`（一次性 warning + degraded 狀態）、`run_loop.run_plugin_cases`（回傳 payload 注入 `agent_session_degraded` key）。builtin-fallback 語意不變。
+
+**Tech Stack:** Python 3.11+、pytest、github-copilot-sdk 0.1.x（僅 smoke，測試全 mock）。
+
+**參照:** spec `docs/superpowers/specs/2026-07-06-copilot-sdk-permission-drift-design.md`、openspec change `copilot-sdk-permission-alignment`、issue #16。
+
+---
+
+### Task 1: permission handler 對齊 0.1.x（TDD）
+
+**Files:**
+- Modify: `src/testpilot/core/copilot_session.py:194-204`
+- Test: `tests/test_copilot_session.py`
+
+- [ ] **Step 1: 改寫既有 fake SDK fixture 並新增 wire-shape RED tests**
+
+`tests/test_copilot_session.py:123` 現行 fake 是舊 API 形狀（`SimpleNamespace(PermissionHandler=SimpleNamespace(approve_all="APPROVE_ALL"))`）。改為 0.1.x 形狀並新增測試：
+
+```python
+# 取代 L123 的 fake_sdk 定義（該測試上下文中 PermissionRequestResult 用 dict 代表 TypedDict）
+fake_sdk = SimpleNamespace(
+    PermissionHandler=None,  # 0.1.x 是 typing alias，getattr 拿到的不是 class
+    PermissionRequestResult=dict,  # TypedDict(total=False) 在 runtime 就是 dict 工廠
+)
+
+def test_resolve_permission_handler_returns_approve_all_callable():
+    manager = CopilotSessionManager(sdk_module=fake_sdk)
+    handler = manager._resolve_permission_handler()
+    assert callable(handler)
+    result = handler(SimpleNamespace(kind="tool-use"), {"tool": "bash"})
+    assert result == {"kind": "approved"}  # wire shape 精確鎖定，防 false-green
+
+def test_resolve_permission_handler_missing_result_type_raises():
+    broken_sdk = SimpleNamespace(PermissionHandler=None)  # 無 PermissionRequestResult
+    manager = CopilotSessionManager(sdk_module=broken_sdk)
+    with pytest.raises(CopilotSDKUnavailableError, match="copilot.PermissionRequestResult is unavailable"):
+        manager._resolve_permission_handler()
+
+def test_injected_permission_handler_wins_without_sdk_touch():
+    sentinel = object()
+    manager = CopilotSessionManager(sdk_module=None, permission_handler=sentinel)
+    assert manager._resolve_permission_handler() is sentinel  # sdk_module=None 而不炸 = 沒碰 SDK
+```
+
+同檔既有 `create_session`/`resume_session` 測試中 `assert created_config["on_permission_request"] == "APPROVE_ALL"`（L176/L182）改為：
+
+```python
+handler = created_config["on_permission_request"]
+assert handler(SimpleNamespace(), {}) == {"kind": "approved"}
+```
+
+- [ ] **Step 2: 跑測試確認 RED**
+
+Run: `cd /home/paul_chen/prj_arc/testpilot-core/.worktrees/16-copilot-sdk-permission && .venv/bin/python -m pytest tests/test_copilot_session.py -v 2>&1 | tail -20`（無 .venv 則先 `uv venv && uv pip install -e ".[dev]"`）
+Expected: 新測試 FAIL——現行實作 raise `copilot.PermissionHandler.approve_all is unavailable`。
+
+- [ ] **Step 3: 改寫 `_resolve_permission_handler`**
+
+```python
+    def _resolve_permission_handler(self) -> Any:
+        if self.permission_handler is not None:
+            return self.permission_handler
+        sdk = self._load_sdk()
+        result_type = getattr(sdk, "PermissionRequestResult", None)
+        if result_type is None:
+            raise CopilotSDKUnavailableError(
+                "copilot.PermissionRequestResult is unavailable"
+            )
+
+        def _approve_all(request: Any, context: Any) -> Any:
+            return result_type(kind="approved")
+
+        return _approve_all
+```
+
+註：`PermissionRequestResult` 是 `TypedDict(total=False)`，`result_type(kind="approved")` 在 runtime 等價 `{"kind": "approved"}`；test fixture 用 `dict` 代表故 assert `== {"kind": "approved"}` 成立。
+
+- [ ] **Step 4: 跑測試確認 GREEN**
+
+Run: 同 Step 2 指令
+Expected: 全 PASS（含改寫後的 create/resume 測試）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/testpilot/core/copilot_session.py tests/test_copilot_session.py
+git commit -m "fix(copilot_session): 對齊 github-copilot-sdk 0.1.x permission handler wire shape (#16)"
+```
+
+### Task 2: loud surfacing——一次性 warning + degraded 狀態（TDD）
+
+**Files:**
+- Modify: `src/testpilot/core/orchestrator.py:150-173`（`_create_case_session`）
+- Test: `tests/test_orchestrator.py`（或既有 orchestrator 測試檔，執行前先 `grep -rn "_create_case_session" tests/` 確認歸屬檔案，無則新建 `tests/test_orchestrator_session_degraded.py`）
+
+- [ ] **Step 1: RED tests——warning 恰一次 + degraded 狀態可讀**
+
+```python
+import logging
+from pathlib import Path
+
+from testpilot.core.orchestrator import Orchestrator
+
+
+class _FailingSessionManager:
+    def create_session(self, request):
+        raise RuntimeError("boom")
+
+
+def _orchestrator_with_failing_sessions() -> Orchestrator:
+    # 比照 tests/test_orchestrator_retry.py:19 的既有建構方式
+    orch = Orchestrator(project_root=Path(__file__).resolve().parents[1])
+    orch.session_manager = _FailingSessionManager()
+    return orch
+
+
+def test_session_failure_warns_once_and_sets_degraded(caplog):
+    orch = _orchestrator_with_failing_sessions()
+    plan = {"session_id": "s1", "model": "m", "reasoning_effort": "high"}
+    with caplog.at_level(logging.WARNING):
+        h1 = orch._create_case_session(dict(plan))
+        h2 = orch._create_case_session(dict(plan))
+    assert h1["status"] == "failed" and h2["status"] == "failed"  # 既有 per-case 行為不變
+    warnings = [r for r in caplog.records
+                if r.levelno == logging.WARNING and "builtin-fallback" in r.getMessage()]
+    assert len(warnings) == 1  # 一次性 loud warning
+    assert orch.agent_session_degraded == {"degraded": True, "reason": "boom"}
+
+
+def test_no_failure_keeps_degraded_false():
+    orch = Orchestrator(project_root=Path(__file__).resolve().parents[1])
+    assert orch.agent_session_degraded == {"degraded": False, "reason": ""}
+```
+
+- [ ] **Step 2: 跑測試確認 RED**
+
+Run: `.venv/bin/python -m pytest tests/test_orchestrator_session_degraded.py -v`
+Expected: FAIL——`agent_session_degraded` 屬性不存在。
+
+- [ ] **Step 3: 實作 orchestrator degraded 追蹤**
+
+`_create_case_session` 修改（保留既有回傳形狀）：
+
+```python
+    # __init__（或 dataclass 欄位區）新增：
+    #   self.agent_session_degraded: dict[str, Any] = {"degraded": False, "reason": ""}
+
+    def _create_case_session(self, session_plan):
+        if self.session_manager is None or CopilotSessionRequest is None:
+            return None
+        try:
+            ...  # 既有建立邏輯不動
+        except Exception as exc:
+            if not self.agent_session_degraded["degraded"]:
+                log.warning(
+                    "SDK session foundation failed; remediation will run with "
+                    "builtin-fallback for the whole run: %s", exc,
+                )
+                self.agent_session_degraded = {"degraded": True, "reason": str(exc)}
+            else:
+                log.debug("SDK session creation failed (already degraded): %s", exc)
+            return {"status": "failed", "error": str(exc)}
+```
+
+- [ ] **Step 4: 跑測試確認 GREEN，並確認既有 orchestrator 測試不破**
+
+Run: `.venv/bin/python -m pytest tests/ -k "orchestrator or copilot" -v 2>&1 | tail -15`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/testpilot/core/orchestrator.py tests/
+git commit -m "feat(orchestrator): session foundation 失敗一次性 loud warning + degraded 狀態 (#16)"
+```
+
+### Task 3: run payload 注入 `agent_session_degraded`（TDD）
+
+**Files:**
+- Modify: `src/testpilot/core/run_loop.py`（`run_plugin_cases` 尾段，`build_reports(run_result)` 返回處，現約 L368-371）
+- Test: 既有 run_loop 測試檔（`grep -rln "run_plugin_cases" tests/` 定位；沿用其 fake plugin/reporter fixture）
+
+- [ ] **Step 1: RED test**
+
+```python
+def test_run_payload_carries_agent_session_degraded(...):
+    # 沿用既有 run_loop 測試的最小 fake plugin + reporter（build_reports 回傳 dict）
+    payload = run_plugin_cases(orchestrator=orch, plugin_name="fake", case_ids=None)
+    assert payload["agent_session_degraded"] == {"degraded": False, "reason": ""}
+
+def test_run_payload_degraded_true_when_sessions_fail(...):
+    # orch.session_manager = _FailingSessionManager()，runner 選 copilot 使 session plan 存在
+    payload = run_plugin_cases(orchestrator=orch, plugin_name="fake", case_ids=None)
+    assert payload["agent_session_degraded"]["degraded"] is True
+    assert "boom" in payload["agent_session_degraded"]["reason"]
+```
+
+- [ ] **Step 2: 跑測試確認 RED**
+
+Run: `.venv/bin/python -m pytest tests/ -k "run_payload" -v`
+Expected: FAIL——payload 無此 key。
+
+- [ ] **Step 3: 實作注入**
+
+`run_loop.py` 尾段：
+
+```python
+    reporter = plugin.create_reporter()
+    build_reports = getattr(reporter, "build_reports", None)
+    if not callable(build_reports):
+        raise RuntimeError(f"{plugin_name} reporter does not implement build_reports()")
+    payload = build_reports(run_result)
+    if isinstance(payload, dict):
+        payload.setdefault(
+            "agent_session_degraded",
+            getattr(orchestrator, "agent_session_degraded", {"degraded": False, "reason": ""}),
+        )
+    return payload
+```
+
+- [ ] **Step 4: 跑測試確認 GREEN + 全套件**
+
+Run: `.venv/bin/python -m pytest -q 2>&1 | tail -5`
+Expected: 全綠（既知 2 個 wheel-probe env fail 除外，比照 REPO-0706 基準）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/testpilot/core/run_loop.py tests/
+git commit -m "feat(run_loop): run payload 注入 agent_session_degraded key (#16)"
+```
+
+### Task 4: smoke + 收尾
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: 真 SDK smoke**
+
+Run: `python3 -c "import sys; sys.path.insert(0,'/home/paul_chen/.local/lib/python3.12/site-packages'); sys.path.insert(0,'src'); from testpilot.core.copilot_session import CopilotSessionManager; h=CopilotSessionManager()._resolve_permission_handler(); print(h(object(), {}))"`
+Expected: 印出 `{'kind': 'approved'}`，不 raise。
+
+- [ ] **Step 2: CHANGELOG entry**
+
+`CHANGELOG.md` `[Unreleased]` 下新增：
+
+```markdown
+### Fixed
+- copilot session foundation 對齊 github-copilot-sdk 0.1.x（`PermissionHandler.approve_all` 已不存在）：自組 approve-all permission handler（wire shape `{"kind": "approved"}`）；session 建立失敗改為一次性 loud warning + run payload `agent_session_degraded` key，終結 silent builtin-fallback（#16）
+```
+
+- [ ] **Step 3: 最終驗證 + Commit**
+
+Run: `.venv/bin/python -m pytest -q 2>&1 | tail -3`
+Expected: 綠。
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): #16 copilot SDK 對齊 entry"
+```
+
+- [ ] **Step 4: openspec tasks 勾選同步**
+
+`openspec/changes/copilot-sdk-permission-alignment/tasks.md` 對應項打勾後隨最終 commit 一併提交。
+
+---
+
+## 驗收（PR 前）
+
+- [ ] `pytest -q` 全綠；smoke 印出 `{'kind': 'approved'}`
+- [ ] `python3 -m policy_check --repo .` 無 failure（core repo 有此 gate 時）
+- [ ] PR body `Closes #16`；R-18 評估（內部行為修復，預期上 `policy-exempt:docs-sync`）
+- [ ] 真機驗證（下輪 wifi_llapi run 的 agent_trace `session_handle.status == "created"`）記入 PR「後續驗證」段，不 block merge

--- a/docs/superpowers/specs/2026-07-06-copilot-sdk-permission-drift-design.md
+++ b/docs/superpowers/specs/2026-07-06-copilot-sdk-permission-drift-design.md
@@ -1,0 +1,81 @@
+# copilot session permission handler 對齊 SDK 0.1.x 設計
+
+> 日期：2026-07-06 ｜ 對應 issue：#16 ｜ repo：testpilot-core
+> 佐證 run：wifi_llapi full-run `20260704T112950138504`（415 案全數 `session_handle.status=failed`）
+
+## 問題背景（root cause）
+
+`src/testpilot/core/copilot_session.py::_resolve_permission_handler`（L194-204）hard-code 依賴
+`copilot.PermissionHandler.approve_all`。實際安裝的 `github-copilot-sdk 0.1.23` 中
+`PermissionHandler` 是 **typing alias**：
+
+```
+Callable[[PermissionRequest, dict[str, str]], PermissionRequestResult | Awaitable[PermissionRequestResult]]
+```
+
+不是帶 `approve_all` classmethod 的 class → `getattr(..., "approve_all")` 恆為 `None` →
+每次 session foundation 建立必然 raise `CopilotSDKUnavailableError` → 全 run remediation
+無聲降級到 `builtin-fallback`（連續兩輪 full-run 都是事後翻 agent_trace 才發現）。
+
+## 設計原則
+
+1. **只支援現行 0.1.x API，不留雙軌**（使用者 2026-07-06 拍板）：移除舊 API 假設，不做
+   class-式/callable-式 feature-detect shim。
+2. session 建立失敗 → builtin-fallback 的既有安全策略**不變**；本設計只讓「失敗」變 loud、
+   且在 0.1.x 下不再必然失敗。
+3. 最小必要變更：只動 `copilot_session.py`、loud-surfacing 掛點、對應測試。
+
+## 元件 1：approve-all permission handler（主修）
+
+`_resolve_permission_handler()` 改為：
+
+- 若 `self.permission_handler` 已注入 → 原樣回傳（現行行為保留）。
+- 否則自組 approve-all callable：接收 `(PermissionRequest, dict[str, str])`，回傳
+  approve 語意的 `PermissionRequestResult`。
+  - `PermissionRequestResult` 的實際建構簽名（欄位名 / kind 值）於實作前對
+    `github-copilot-sdk 0.1.23` 原始碼確認，**不得憑空猜欄位**。
+  - 回傳值同時容許 sync 形式（SDK 型別本身容許 Awaitable，自組 handler 用 sync 即可）。
+- 若 SDK 缺 `PermissionRequestResult`（或建構必要 surface 缺失）→ 仍 raise
+  `CopilotSDKUnavailableError`，訊息**指名缺的 symbol**（例：
+  `"copilot.PermissionRequestResult is unavailable"`）。
+
+## 元件 2：loud surfacing（degraded 可見性）
+
+- run 內**第一次** session foundation 建立失敗時：`log.warning` 一次（不逐案洗版），
+  內容含失敗原因與「remediation 將全程 builtin-fallback」的明確語句。
+- run-level metadata 增加 degraded 標記（如 `agent_session_degraded: true` + 原因字串），
+  落點在 core 已有的 run summary / trace metadata 結構，供 plugin 報表與人工檢視。
+- 每案 selection trace 的 `session_handle` 記錄行為維持不變。
+
+## 測試（TDD）
+
+mock SDK module（不依賴真 `copilot` 安裝）：
+
+1. **0.1.x surface**：`PermissionHandler` 為 typing alias、`PermissionRequestResult` 存在
+   → `_resolve_permission_handler()` 回傳 callable；以 `PermissionRequest` mock 呼叫之，
+   回傳 approve 語意結果。
+2. **缺 API surface**：移除 `PermissionRequestResult` → raise `CopilotSDKUnavailableError`
+   且訊息指名缺的 symbol。
+3. **注入 handler 優先**：`permission_handler` 已注入時不碰 SDK。
+4. **loud surfacing**：第一次失敗 warning 恰好一次；degraded 標記寫入 run metadata。
+5. 更新既有 `tests/test_copilot_session.py` 中對 `approve_all` 的假設。
+
+## 驗收標準
+
+- [ ] unit tests 全綠（含上列新測試）。
+- [ ] smoke：在裝有 `github-copilot-sdk 0.1.23` 的環境 import 真 SDK，
+      `_resolve_permission_handler()` 成功回傳 callable（不 raise）。
+- [ ] 失敗路徑 warning 只出現一次且訊息可讀。
+- [ ] CHANGELOG `[Unreleased]` 有 entry；PR body `Closes #16`。
+
+## 約束
+
+- 不動 execution loop 的 fallback 語意（`execution_engine` 的 builtin classifier 路徑）。
+- 不引入新依賴；不 pin SDK 版本（feature-detect symbol 存在與否即可）。
+- 真機 full-run 端到端驗證（remediation session 實際上工）屬後續批次，不在本 change 範圍。
+
+## 非目標（YAGNI）
+
+- 不做多版本 SDK 相容矩陣。
+- 不改 remediation 白名單 / decision 格式。
+- 不做 session 內容（prompt/tooling）優化——僅恢復 session foundation 可建立。

--- a/docs/superpowers/specs/2026-07-06-copilot-sdk-permission-drift-design.md
+++ b/docs/superpowers/specs/2026-07-06-copilot-sdk-permission-drift-design.md
@@ -32,28 +32,39 @@ Callable[[PermissionRequest, dict[str, str]], PermissionRequestResult | Awaitabl
 - 若 `self.permission_handler` 已注入 → 原樣回傳（現行行為保留）。
 - 否則自組 approve-all callable：接收 `(PermissionRequest, dict[str, str])`，回傳
   approve 語意的 `PermissionRequestResult`。
-  - `PermissionRequestResult` 的實際建構簽名（欄位名 / kind 值）於實作前對
-    `github-copilot-sdk 0.1.23` 原始碼確認，**不得憑空猜欄位**。
-  - 回傳值同時容許 sync 形式（SDK 型別本身容許 Awaitable，自組 handler 用 sync 即可）。
-- 若 SDK 缺 `PermissionRequestResult`（或建構必要 surface 缺失）→ 仍 raise
-  `CopilotSDKUnavailableError`，訊息**指名缺的 symbol**（例：
+  - **wire shape（adversarial review 確認，0.1.23 `types.py`）**：
+    `PermissionRequestResult` 是 `TypedDict(total=False)`，欄位 `kind` / `rules`；
+    approve 的唯一正確形狀是 **`{"kind": "approved"}`**。TypedDict 不做 runtime
+    validation、SDK `session.py` 直接回送 handler 回傳值——錯欄位（如
+    `behavior="allow"`）不會報錯但也不會被視為 approve，**測試必須鎖 wire shape**
+    （assert 回傳 dict == `{"kind": "approved"}`），不得只驗 callable 有被呼叫。
+  - 回傳值用 sync 形式（SDK 型別容許 Awaitable，自組 handler 不需要）。
+- feature-detect 的對象**只有 `PermissionRequestResult` 的可用性**（不再偵測任何
+  `approve_all` symbol）：SDK 缺 `PermissionRequestResult` → raise
+  `CopilotSDKUnavailableError`，訊息指名缺的 symbol（例：
   `"copilot.PermissionRequestResult is unavailable"`）。
 
 ## 元件 2：loud surfacing（degraded 可見性）
 
 - run 內**第一次** session foundation 建立失敗時：`log.warning` 一次（不逐案洗版），
   內容含失敗原因與「remediation 將全程 builtin-fallback」的明確語句。
-- run-level metadata 增加 degraded 標記（如 `agent_session_degraded: true` + 原因字串），
-  落點在 core 已有的 run summary / trace metadata 結構，供 plugin 報表與人工檢視。
+- **run-level 落點（adversarial review 指出現行結構無此欄位，需新增）**：
+  `run_loop` 的回傳 payload 是 `dict[str, Any]`（`run_loop.py::run_plugin_cases`），
+  新增 key `agent_session_degraded: {"degraded": bool, "reason": str}`——由
+  orchestrator/session 管理層在第一次失敗時設置。此為**小幅 core schema 變更**，
+  屬本 change 範圍。
+- plugin reporter 是否消費此 key 屬 wifi_llapi 側 follow-up，不在本 change 範圍；
+  本 change 的可驗收面是 warning log + run payload key 存在且值正確。
 - 每案 selection trace 的 `session_handle` 記錄行為維持不變。
 
 ## 測試（TDD）
 
 mock SDK module（不依賴真 `copilot` 安裝）：
 
-1. **0.1.x surface**：`PermissionHandler` 為 typing alias、`PermissionRequestResult` 存在
-   → `_resolve_permission_handler()` 回傳 callable；以 `PermissionRequest` mock 呼叫之，
-   回傳 approve 語意結果。
+1. **0.1.x surface + wire shape lock**：`PermissionHandler` 為 typing alias、
+   `PermissionRequestResult` 存在 → `_resolve_permission_handler()` 回傳 callable；
+   以 `PermissionRequest` mock 呼叫之，**assert 回傳值精確等於 `{"kind": "approved"}`**
+   （防 false-green：只驗「被呼叫」不足）。
 2. **缺 API surface**：移除 `PermissionRequestResult` → raise `CopilotSDKUnavailableError`
    且訊息指名缺的 symbol。
 3. **注入 handler 優先**：`permission_handler` 已注入時不碰 SDK。
@@ -71,7 +82,8 @@ mock SDK module（不依賴真 `copilot` 安裝）：
 ## 約束
 
 - 不動 execution loop 的 fallback 語意（`execution_engine` 的 builtin classifier 路徑）。
-- 不引入新依賴；不 pin SDK 版本（feature-detect symbol 存在與否即可）。
+- 不引入新依賴；不 pin SDK 版本（feature-detect 僅針對 `PermissionRequestResult`
+  可用性，與「不留雙軌」原則一致——不偵測、不相容任何 `approve_all` 形式的舊 API）。
 - 真機 full-run 端到端驗證（remediation session 實際上工）屬後續批次，不在本 change 範圍。
 
 ## 非目標（YAGNI）

--- a/openspec/changes/copilot-sdk-permission-alignment/.openspec.yaml
+++ b/openspec/changes/copilot-sdk-permission-alignment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/copilot-sdk-permission-alignment/design.md
+++ b/openspec/changes/copilot-sdk-permission-alignment/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`copilot_session.py::_resolve_permission_handler`（L194-204）以 `getattr(sdk.PermissionHandler, "approve_all")` 取得 permission handler；`github-copilot-sdk 0.1.23` 的 `PermissionHandler` 是 typing alias（`Callable[[PermissionRequest, dict[str, str]], PermissionRequestResult | Awaitable[...]]`），`approve_all` 恆為 `None` → 每次 session 建立必然 raise → execution engine 每案 fallback 到 builtin classifier，且僅記錄於 per-case selection trace（silent）。
+
+設計基準與完整需求見 `docs/superpowers/specs/2026-07-06-copilot-sdk-permission-drift-design.md`（已過 codex 對抗性審查一輪 + 修正）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- session foundation 在 SDK 0.1.x 下可成功建立（approve-all wire shape 正確）
+- 建立失敗時 loud：一次性 warning + run-level degraded 標記
+- SDK 契約 guard tests（wire shape 鎖定）
+
+**Non-Goals:**
+- 不做多版本 SDK 相容矩陣、不 pin 版本
+- 不改 builtin-fallback 語意與 remediation 白名單
+- wifi_llapi reporter 消費 degraded key（wifi 側 follow-up）
+- 真機 full-run 端到端驗證（後續批次）
+
+## Decisions
+
+1. **只支援 0.1.x、不留雙軌**（使用者 2026-07-06 拍板）：自組 callable 回傳 `{"kind": "approved"}`；替代方案「feature-detect 雙軌 shim」被否決（多維護一條死路徑，違反不留雙軌原則）。
+2. **wire shape 以測試鎖定**：`PermissionRequestResult` 是 `TypedDict(total=False)`（欄位 `kind`/`rules`），SDK `session.py` 直接回送 handler 回傳值、無 runtime validation——錯欄位不報錯也不生效。故測試必須 assert 回傳 dict 精確等於 `{"kind": "approved"}`，不得只驗 callable 被呼叫（防 false-green；codex review Critical finding）。
+3. **degraded 落點 = `run_loop` 回傳 payload**：`run_plugin_cases()` 回傳 `dict[str, Any]`，新增 `agent_session_degraded: {"degraded": bool, "reason": str}` key。替代方案「寫進 RunResult/reporter meta」需動更多 schema 與 plugin 介面，超出最小必要變更。
+4. **feature-detect 僅針對 `PermissionRequestResult` 可用性**：缺失 → `CopilotSDKUnavailableError("copilot.PermissionRequestResult is unavailable")`；不偵測任何 `approve_all` 形式。
+
+## Risks / Trade-offs
+
+- [SDK 0.2+ 再次 drift] → guard test 鎖 wire shape，drift 時測試紅（明確訊號），屆時再議
+- [warning 只打一次可能被 log 洪水淹沒] → 同步落 run payload key，報表層可後續消費
+- [`{"kind": "approved"}` 語意過寬（全部核准）] → 與原 `approve_all` 意圖一致；session 用途為 remediation 決策諮詢，工具權限邊界由 plugin 白名單另行把關
+
+## Migration Plan
+
+單 PR：改 `copilot_session.py` + `run_loop.py` degraded key + 測試 + CHANGELOG。無資料遷移；rollback = revert commit。合併後由下一次 wifi_llapi run 的 agent_trace 驗證 `session_handle.status` 不再是 failed。

--- a/openspec/changes/copilot-sdk-permission-alignment/proposal.md
+++ b/openspec/changes/copilot-sdk-permission-alignment/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+wifi_llapi full-run `20260704T112950138504` 全數 415 案的 agent session foundation 建立失敗（`copilot.PermissionHandler.approve_all is unavailable`），remediation 整場 silent 降級到 builtin-fallback——core 寫死的 `PermissionHandler.approve_all` 在實裝 `github-copilot-sdk 0.1.23` 中不存在（`PermissionHandler` 是 typing alias，非 class）。連續兩輪 full-run 都是事後翻 agent_trace 才發現（#16）。
+
+## What Changes
+
+- 重寫 `copilot_session.py::_resolve_permission_handler`：自組 approve-all permission handler callable，回傳 wire shape 正確的 `{"kind": "approved"}`（`PermissionRequestResult` 為 `TypedDict(total=False)`，無 runtime validation，測試鎖 wire shape）
+- feature-detect 對象改為 `PermissionRequestResult` 可用性；缺失時 `CopilotSDKUnavailableError` 指名缺的 symbol；**不留任何 `approve_all` 舊 API 雙軌**
+- 新增 loud surfacing：run 內第一次 session 建立失敗 → 一次性 `log.warning` + `run_loop` 回傳 payload 新增 `agent_session_degraded` key（小幅 core schema 變更）
+- 更新 `tests/test_copilot_session.py` 對 `approve_all` 的假設；新增 wire-shape 鎖定與缺 API 測試
+- CHANGELOG `[Unreleased]` entry
+
+## Capabilities
+
+### New Capabilities
+- `copilot-session-foundation`: copilot-sdk session foundation 的建立契約——permission handler wire shape、SDK surface feature-detect、建立失敗時的 loud surfacing 與 degraded 標記
+
+### Modified Capabilities
+
+（無——execution loop 的 builtin-fallback 行為與 selection trace 記錄不變）
+
+## Impact
+
+- `src/testpilot/core/copilot_session.py`（主修）
+- `src/testpilot/core/run_loop.py` / orchestrator（degraded key 落點）
+- `tests/test_copilot_session.py`（更新 + 新增）
+- 依賴：`github-copilot-sdk 0.1.x`（不 pin、不新增依賴）
+- 下游：wifi_llapi remediation 恢復 agent 決策能力（reporter 消費 degraded key 屬 wifi 側 follow-up，不在本 change）

--- a/openspec/changes/copilot-sdk-permission-alignment/specs/copilot-session-foundation/spec.md
+++ b/openspec/changes/copilot-sdk-permission-alignment/specs/copilot-session-foundation/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: permission handler SHALL 以 SDK 0.1.x wire shape 自組 approve-all callable
+
+`_resolve_permission_handler()` 在未注入自訂 handler 時，SHALL 回傳一個 callable：接收 `(PermissionRequest, dict[str, str])`、以 sync 形式回傳精確等於 `{"kind": "approved"}` 的 `PermissionRequestResult`。實作 MUST NOT 依賴任何 `PermissionHandler.approve_all` 形式的 API。
+
+#### Scenario: SDK 0.1.x surface 下建立 handler
+- **WHEN** `copilot` module 可 import 且 `PermissionRequestResult` 存在
+- **THEN** `_resolve_permission_handler()` 回傳 callable
+- **AND** 以任意 `PermissionRequest` 呼叫該 callable 回傳 `{"kind": "approved"}`（精確相等）
+
+#### Scenario: 已注入自訂 handler
+- **WHEN** `permission_handler` 建構時已注入
+- **THEN** 原樣回傳注入值，不觸碰 SDK surface
+
+### Requirement: SDK surface 缺失 SHALL raise 指名 symbol 的錯誤
+
+feature-detect 的對象 SHALL 僅為 `PermissionRequestResult` 的可用性。
+
+#### Scenario: SDK 缺 PermissionRequestResult
+- **WHEN** `copilot` module 可 import 但無 `PermissionRequestResult`
+- **THEN** raise `CopilotSDKUnavailableError`，訊息含 `"copilot.PermissionRequestResult is unavailable"`
+
+### Requirement: session foundation 建立失敗 SHALL loud surfacing
+
+session foundation 建立失敗 MUST 維持既有 builtin-fallback 行為，且 SHALL 同時：run 內第一次失敗時發出恰一次 `log.warning`（含失敗原因與「remediation 將全程 builtin-fallback」語句）、在 `run_plugin_cases()` 回傳 payload 設置 `agent_session_degraded` key。
+
+#### Scenario: run 內第一次 session 建立失敗
+- **WHEN** 任一 case 的 session foundation 建立失敗且該 run 先前無失敗記錄
+- **THEN** 發出一次 `log.warning`
+- **AND** run payload `agent_session_degraded == {"degraded": true, "reason": <失敗原因>}`
+
+#### Scenario: 同 run 後續 case 再失敗
+- **WHEN** 同一 run 內第二個以上 case 的 session 建立失敗
+- **THEN** 不再重複 warning
+- **AND** per-case selection trace 的 `session_handle` 記錄維持既有行為
+
+#### Scenario: session 全程正常
+- **WHEN** 整個 run 無 session 建立失敗
+- **THEN** run payload `agent_session_degraded == {"degraded": false, "reason": ""}`（或等價 falsy 慣例，實作時擇一並以測試鎖定）

--- a/openspec/changes/copilot-sdk-permission-alignment/tasks.md
+++ b/openspec/changes/copilot-sdk-permission-alignment/tasks.md
@@ -1,0 +1,26 @@
+## 1. TDD RED — SDK 契約測試先行
+
+- [ ] 1.1 建 mock SDK module fixture：`PermissionHandler` 為 typing alias、`PermissionRequestResult` 為 `TypedDict(total=False)`（比照 0.1.23 surface）
+- [ ] 1.2 RED test：`_resolve_permission_handler()` 回傳 callable 且以 `PermissionRequest` mock 呼叫回傳精確 `{"kind": "approved"}`（現行實作應 fail：raise approve_all unavailable）
+- [ ] 1.3 RED test：mock SDK 移除 `PermissionRequestResult` → raise `CopilotSDKUnavailableError` 且訊息含 `copilot.PermissionRequestResult is unavailable`
+- [ ] 1.4 RED test：注入 `permission_handler` 時原樣回傳、不觸 SDK
+- [ ] 1.5 清點 `tests/test_copilot_session.py` 既有 `approve_all` 假設測試，標記待改清單
+
+## 2. 實作 — permission handler 對齊
+
+- [ ] 2.1 重寫 `_resolve_permission_handler()`：feature-detect `PermissionRequestResult` → 自組 approve-all callable（回傳 `{"kind": "approved"}`）
+- [ ] 2.2 移除 `PermissionHandler.approve_all` 相關程式碼與錯誤訊息（不留雙軌）
+- [ ] 2.3 更新 1.5 清單中的既有測試至新契約；1.1–1.4 測試轉綠
+
+## 3. 實作 — loud surfacing
+
+- [ ] 3.1 RED test：run 內第一次 session 建立失敗 → 恰一次 `log.warning`；後續失敗不重複
+- [ ] 3.2 RED test：`run_plugin_cases()` 回傳 payload 含 `agent_session_degraded`（失敗 run = `{"degraded": true, "reason": ...}`；正常 run 的 falsy 形狀以測試鎖定）
+- [ ] 3.3 實作 orchestrator/run_loop 的 degraded 狀態追蹤與 payload key；3.1–3.2 轉綠
+
+## 4. 收尾
+
+- [ ] 4.1 smoke：在裝有 `github-copilot-sdk 0.1.23` 的環境 import 真 SDK，`_resolve_permission_handler()` 成功回傳 callable
+- [ ] 4.2 全套件測試綠（core repo 測試指令）
+- [ ] 4.3 CHANGELOG `[Unreleased]` entry；PR body `Closes #16`
+- [ ] 4.4 檢查 R-18：README/docs 是否需同步（純內部行為修復，預期 `policy-exempt:docs-sync` 或無需變更）

--- a/openspec/changes/copilot-sdk-permission-alignment/tasks.md
+++ b/openspec/changes/copilot-sdk-permission-alignment/tasks.md
@@ -1,26 +1,26 @@
 ## 1. TDD RED — SDK 契約測試先行
 
-- [ ] 1.1 建 mock SDK module fixture：`PermissionHandler` 為 typing alias、`PermissionRequestResult` 為 `TypedDict(total=False)`（比照 0.1.23 surface）
-- [ ] 1.2 RED test：`_resolve_permission_handler()` 回傳 callable 且以 `PermissionRequest` mock 呼叫回傳精確 `{"kind": "approved"}`（現行實作應 fail：raise approve_all unavailable）
-- [ ] 1.3 RED test：mock SDK 移除 `PermissionRequestResult` → raise `CopilotSDKUnavailableError` 且訊息含 `copilot.PermissionRequestResult is unavailable`
-- [ ] 1.4 RED test：注入 `permission_handler` 時原樣回傳、不觸 SDK
-- [ ] 1.5 清點 `tests/test_copilot_session.py` 既有 `approve_all` 假設測試，標記待改清單
+- [x] 1.1 建 mock SDK module fixture：`PermissionHandler` 為 typing alias、`PermissionRequestResult` 為 `TypedDict(total=False)`（比照 0.1.23 surface）
+- [x] 1.2 RED test：`_resolve_permission_handler()` 回傳 callable 且以 `PermissionRequest` mock 呼叫回傳精確 `{"kind": "approved"}`（現行實作應 fail：raise approve_all unavailable）
+- [x] 1.3 RED test：mock SDK 移除 `PermissionRequestResult` → raise `CopilotSDKUnavailableError` 且訊息含 `copilot.PermissionRequestResult is unavailable`
+- [x] 1.4 RED test：注入 `permission_handler` 時原樣回傳、不觸 SDK
+- [x] 1.5 清點 `tests/test_copilot_session.py` 既有 `approve_all` 假設測試，標記待改清單
 
 ## 2. 實作 — permission handler 對齊
 
-- [ ] 2.1 重寫 `_resolve_permission_handler()`：feature-detect `PermissionRequestResult` → 自組 approve-all callable（回傳 `{"kind": "approved"}`）
-- [ ] 2.2 移除 `PermissionHandler.approve_all` 相關程式碼與錯誤訊息（不留雙軌）
-- [ ] 2.3 更新 1.5 清單中的既有測試至新契約；1.1–1.4 測試轉綠
+- [x] 2.1 重寫 `_resolve_permission_handler()`：feature-detect `PermissionRequestResult` → 自組 approve-all callable（回傳 `{"kind": "approved"}`）
+- [x] 2.2 移除 `PermissionHandler.approve_all` 相關程式碼與錯誤訊息（不留雙軌）
+- [x] 2.3 更新 1.5 清單中的既有測試至新契約；1.1–1.4 測試轉綠
 
 ## 3. 實作 — loud surfacing
 
-- [ ] 3.1 RED test：run 內第一次 session 建立失敗 → 恰一次 `log.warning`；後續失敗不重複
-- [ ] 3.2 RED test：`run_plugin_cases()` 回傳 payload 含 `agent_session_degraded`（失敗 run = `{"degraded": true, "reason": ...}`；正常 run 的 falsy 形狀以測試鎖定）
-- [ ] 3.3 實作 orchestrator/run_loop 的 degraded 狀態追蹤與 payload key；3.1–3.2 轉綠
+- [x] 3.1 RED test：run 內第一次 session 建立失敗 → 恰一次 `log.warning`；後續失敗不重複
+- [x] 3.2 RED test：`run_plugin_cases()` 回傳 payload 含 `agent_session_degraded`（失敗 run = `{"degraded": true, "reason": ...}`；正常 run 的 falsy 形狀以測試鎖定）
+- [x] 3.3 實作 orchestrator/run_loop 的 degraded 狀態追蹤與 payload key；3.1–3.2 轉綠
 
 ## 4. 收尾
 
-- [ ] 4.1 smoke：在裝有 `github-copilot-sdk 0.1.23` 的環境 import 真 SDK，`_resolve_permission_handler()` 成功回傳 callable
-- [ ] 4.2 全套件測試綠（core repo 測試指令）
-- [ ] 4.3 CHANGELOG `[Unreleased]` entry；PR body `Closes #16`
-- [ ] 4.4 檢查 R-18：README/docs 是否需同步（純內部行為修復，預期 `policy-exempt:docs-sync` 或無需變更）
+- [x] 4.1 smoke：在裝有 `github-copilot-sdk 0.1.23` 的環境 import 真 SDK，`_resolve_permission_handler()` 成功回傳 callable
+- [x] 4.2 全套件測試綠（core repo 測試指令）
+- [x] 4.3 CHANGELOG `[Unreleased]` entry；PR body `Closes #16`
+- [x] 4.4 檢查 R-18：README/docs 是否需同步（純內部行為修復，預期 `policy-exempt:docs-sync` 或無需變更）

--- a/src/testpilot/core/copilot_session.py
+++ b/src/testpilot/core/copilot_session.py
@@ -195,13 +195,16 @@ class CopilotSessionManager:
         if self.permission_handler is not None:
             return self.permission_handler
         sdk = self._load_sdk()
-        permission_handler_cls = getattr(sdk, "PermissionHandler", None)
-        approve_all = getattr(permission_handler_cls, "approve_all", None)
-        if approve_all is None:
+        result_type = getattr(sdk, "PermissionRequestResult", None)
+        if result_type is None:
             raise CopilotSDKUnavailableError(
-                "copilot.PermissionHandler.approve_all is unavailable"
+                "copilot.PermissionRequestResult is unavailable"
             )
-        return approve_all
+
+        def _approve_all(request: Any, context: Any) -> Any:
+            return result_type(kind="approved")
+
+        return _approve_all
 
     @staticmethod
     async def _maybe_await(value: Any) -> Any:

--- a/src/testpilot/core/orchestrator.py
+++ b/src/testpilot/core/orchestrator.py
@@ -95,6 +95,15 @@ class Orchestrator(OrchestratorRunBackendCompat):
         # status so the failure is warned once and carried in the run payload.
         self.agent_session_degraded: dict[str, Any] = {"degraded": False, "reason": ""}
 
+    def _reset_run_state(self) -> None:
+        """Reset per-run state at the start of each run.
+
+        ``agent_session_degraded`` (#16) is run-scoped, not instance-scoped:
+        without this reset a reused Orchestrator instance would leak a prior
+        run's degraded status into the next run's payload.
+        """
+        self.agent_session_degraded = {"degraded": False, "reason": ""}
+
     @property
     def run_handle(self) -> RunHandle | None:
         return self._run_handle
@@ -364,6 +373,7 @@ class Orchestrator(OrchestratorRunBackendCompat):
         - core run_loop if plugin exposes a reporter with build_reports()
         - otherwise keeps skeleton behavior
         """
+        self._reset_run_state()
         plugin = self.loader.load(plugin_name)
         create_runner = getattr(plugin, "create_runner", None)
         runner = create_runner() if callable(create_runner) else None

--- a/src/testpilot/core/orchestrator.py
+++ b/src/testpilot/core/orchestrator.py
@@ -90,6 +90,10 @@ class Orchestrator(OrchestratorRunBackendCompat):
         self.runner_selector = RunnerSelector(self.plugins_dir)
         self.execution_engine = ExecutionEngine(self.config)
         self.session_manager: CopilotSessionManager | None = self._try_init_session_manager()
+        # Loud surfacing (#16): when the SDK session foundation fails, remediation
+        # silently falls back to the builtin classifier. Track a run-level degraded
+        # status so the failure is warned once and carried in the run payload.
+        self.agent_session_degraded: dict[str, Any] = {"degraded": False, "reason": ""}
 
     @property
     def run_handle(self) -> RunHandle | None:
@@ -169,7 +173,15 @@ class Orchestrator(OrchestratorRunBackendCompat):
                 "status": "created",
             }
         except Exception as exc:
-            log.warning("SDK session creation failed: %s", exc)
+            if not self.agent_session_degraded["degraded"]:
+                log.warning(
+                    "SDK session foundation failed; remediation will run with "
+                    "builtin-fallback for the whole run: %s",
+                    exc,
+                )
+                self.agent_session_degraded = {"degraded": True, "reason": str(exc)}
+            else:
+                log.debug("SDK session creation failed (already degraded): %s", exc)
             return {"status": "failed", "error": str(exc)}
 
     def _cleanup_case_session(self, session_id: str | None) -> None:

--- a/src/testpilot/core/run_loop.py
+++ b/src/testpilot/core/run_loop.py
@@ -368,7 +368,17 @@ def run(
     build_reports = getattr(reporter, "build_reports", None)
     if not callable(build_reports):
         raise RuntimeError(f"{plugin_name} reporter does not implement build_reports()")
-    return build_reports(run_result)
+    payload = build_reports(run_result)
+    if isinstance(payload, dict):
+        payload.setdefault(
+            "agent_session_degraded",
+            getattr(
+                orchestrator,
+                "agent_session_degraded",
+                {"degraded": False, "reason": ""},
+            ),
+        )
+    return payload
 
 
 run_cases = run

--- a/tests/test_copilot_session.py
+++ b/tests/test_copilot_session.py
@@ -118,9 +118,40 @@ def test_build_case_session_plan_for_copilot_runner():
     }
 
 
+# 0.1.x SDK surface: PermissionHandler 是 typing alias（getattr 拿到的不是 class）、
+# PermissionRequestResult 是 TypedDict(total=False)，runtime 等價 dict 工廠。
+fake_sdk = SimpleNamespace(
+    PermissionHandler=None,
+    PermissionRequestResult=dict,
+)
+
+
+def test_resolve_permission_handler_returns_approve_all_callable():
+    manager = CopilotSessionManager(sdk_module=fake_sdk)
+    handler = manager._resolve_permission_handler()
+    assert callable(handler)
+    result = handler(SimpleNamespace(kind="tool-use"), {"tool": "bash"})
+    assert result == {"kind": "approved"}  # wire shape 精確鎖定，防 false-green
+
+
+def test_resolve_permission_handler_missing_result_type_raises():
+    broken_sdk = SimpleNamespace(PermissionHandler=None)  # 無 PermissionRequestResult
+    manager = CopilotSessionManager(sdk_module=broken_sdk)
+    with pytest.raises(
+        CopilotSDKUnavailableError,
+        match="copilot.PermissionRequestResult is unavailable",
+    ):
+        manager._resolve_permission_handler()
+
+
+def test_injected_permission_handler_wins_without_sdk_touch():
+    sentinel = object()
+    manager = CopilotSessionManager(sdk_module=None, permission_handler=sentinel)
+    assert manager._resolve_permission_handler() is sentinel  # sdk_module=None 而不炸 = 沒碰 SDK
+
+
 def test_create_resume_list_delete_session_via_sdk_adapter():
     fake_client = _FakeClient()
-    fake_sdk = SimpleNamespace(PermissionHandler=SimpleNamespace(approve_all="APPROVE_ALL"))
     manager = CopilotSessionManager(
         sdk_module=fake_sdk,
         client_factory=lambda: fake_client,
@@ -173,13 +204,15 @@ def test_create_resume_list_delete_session_via_sdk_adapter():
     assert created_config["disabled_skills"] == ["legacy-skill"]
     assert created_config["streaming"] is True
     assert created_config["client_name"] == "testpilot"
-    assert created_config["on_permission_request"] == "APPROVE_ALL"
+    created_handler = created_config["on_permission_request"]
+    assert created_handler(SimpleNamespace(), {}) == {"kind": "approved"}
 
     resumed_session_id, resumed_config = fake_client.resumed_configs[0]
     assert resumed_session_id == request.session_id
     assert "session_id" not in resumed_config
     assert resumed_config["disable_resume"] is True
-    assert resumed_config["on_permission_request"] == "APPROVE_ALL"
+    resumed_handler = resumed_config["on_permission_request"]
+    assert resumed_handler(SimpleNamespace(), {}) == {"kind": "approved"}
 
     assert len(listed) == 1
     assert listed[0].session_id == "run-20260311-case-wifi-llapi-D001"

--- a/tests/test_orchestrator_session_degraded.py
+++ b/tests/test_orchestrator_session_degraded.py
@@ -1,0 +1,45 @@
+"""Tests for orchestrator SDK session foundation loud surfacing (#16).
+
+When the SDK session foundation fails, the orchestrator must warn exactly once
+(loud, not silent) and expose a degraded status so the run payload can carry it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from testpilot.core.orchestrator import Orchestrator
+
+
+class _FailingSessionManager:
+    def create_session(self, request):
+        raise RuntimeError("boom")
+
+
+def _orchestrator_with_failing_sessions() -> Orchestrator:
+    # 比照 tests/test_orchestrator_retry.py:19 的既有建構方式
+    orch = Orchestrator(project_root=Path(__file__).resolve().parents[1])
+    orch.session_manager = _FailingSessionManager()
+    return orch
+
+
+def test_session_failure_warns_once_and_sets_degraded(caplog):
+    orch = _orchestrator_with_failing_sessions()
+    plan = {"session_id": "s1", "model": "m", "reasoning_effort": "high"}
+    with caplog.at_level(logging.WARNING):
+        h1 = orch._create_case_session(dict(plan))
+        h2 = orch._create_case_session(dict(plan))
+    assert h1["status"] == "failed" and h2["status"] == "failed"  # 既有 per-case 行為不變
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "builtin-fallback" in r.getMessage()
+    ]
+    assert len(warnings) == 1  # 一次性 loud warning
+    assert orch.agent_session_degraded == {"degraded": True, "reason": "boom"}
+
+
+def test_no_failure_keeps_degraded_false():
+    orch = Orchestrator(project_root=Path(__file__).resolve().parents[1])
+    assert orch.agent_session_degraded == {"degraded": False, "reason": ""}

--- a/tests/test_orchestrator_session_degraded.py
+++ b/tests/test_orchestrator_session_degraded.py
@@ -43,3 +43,12 @@ def test_session_failure_warns_once_and_sets_degraded(caplog):
 def test_no_failure_keeps_degraded_false():
     orch = Orchestrator(project_root=Path(__file__).resolve().parents[1])
     assert orch.agent_session_degraded == {"degraded": False, "reason": ""}
+
+
+def test_reset_run_state_clears_stale_degraded():
+    # degraded 語意應綁單次 run，非實例壽命：run 入口重置，避免同一實例
+    # 被 reuse 跑第二次 run 時，前一次的 degraded=True 漏進第二次 payload。
+    orch = Orchestrator(project_root=Path(__file__).resolve().parents[1])
+    orch.agent_session_degraded = {"degraded": True, "reason": "prev-run"}
+    orch._reset_run_state()
+    assert orch.agent_session_degraded == {"degraded": False, "reason": ""}

--- a/tests/test_run_loop_session_degraded.py
+++ b/tests/test_run_loop_session_degraded.py
@@ -1,0 +1,98 @@
+"""Tests for run_loop payload carrying agent_session_degraded (#16).
+
+The core run loop must project the orchestrator's run-level
+``agent_session_degraded`` status into the report payload so the SDK session
+foundation failure is loud (not silent) all the way out to the run result.
+
+These tests drive ``run_loop.run`` with a hermetic stub orchestrator + fake
+plugin/reporter (no real run backend / serialwrap) so they stay hardware-free.
+The ``_create_case_session`` → ``agent_session_degraded`` wiring itself is
+covered by ``tests/test_orchestrator_session_degraded.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from testpilot.core import run_loop
+from testpilot.core.prepared_run import PreparedRun
+
+
+class _FakeReporter:
+    def build_reports(self, run_result: Any) -> dict[str, Any]:
+        return {"status": "ok", "cases_count": run_result.cases_count}
+
+
+class _FakePlugin:
+    version = "0.1.0"
+    name = "fake"
+
+    def prepare_run(self, case_ids: Any) -> PreparedRun:
+        return PreparedRun(cases=[], artifacts={})
+
+    def execution_policy(self, case: Any) -> dict[str, Any]:
+        return {}
+
+    def create_reporter(self) -> _FakeReporter:
+        return _FakeReporter()
+
+
+class _FakeLoader:
+    def __init__(self, plugin: _FakePlugin) -> None:
+        self._plugin = plugin
+
+    def load(self, name: str) -> _FakePlugin:
+        return self._plugin
+
+
+class _FakeRunBackend:
+    def mark_position(self, handle: Any) -> int | None:
+        return None
+
+
+class _FakeRunnerSelector:
+    def load_agent_config(self, plugin_name: str, *, plugin: Any) -> dict[str, Any]:
+        return {}
+
+    def build_execution_policy(self, agent_config: dict[str, Any]) -> dict[str, Any]:
+        return {"mode": "sequential", "max_concurrency": 1}
+
+
+class _StubOrchestrator:
+    """Minimal orchestrator surface exercised by run_loop.run with zero cases."""
+
+    def __init__(self, plugins_dir: Path, degraded: dict[str, Any]) -> None:
+        self.plugins_dir = plugins_dir
+        self.loader = _FakeLoader(_FakePlugin())
+        self.run_backend = _FakeRunBackend()
+        self.runner_selector = _FakeRunnerSelector()
+        self.run_handle = None
+        self.agent_session_degraded = degraded
+
+    def _start_run_capture(self, run_id: str) -> Path | None:
+        return None
+
+    def _stop_run_capture(self) -> None:
+        return None
+
+    def _build_execution_engine(self, *, plugin_name: str, plugin: Any, agent_config: dict) -> None:
+        return None
+
+    def _export_run_logs(self, **kwargs: Any) -> dict[str, str]:
+        return {}
+
+
+def test_run_payload_carries_agent_session_degraded(tmp_path: Path) -> None:
+    orch = _StubOrchestrator(tmp_path, {"degraded": False, "reason": ""})
+    payload = run_loop.run(orch, "fake", None, None)
+    assert payload["agent_session_degraded"] == {"degraded": False, "reason": ""}
+
+
+def test_run_payload_degraded_true_when_sessions_fail(tmp_path: Path) -> None:
+    # session foundation 在 run 中失敗後 orchestrator.agent_session_degraded 被標記
+    # （見 test_orchestrator_session_degraded）；payload 必須原樣攜出。
+    orch = _StubOrchestrator(tmp_path, {"degraded": True, "reason": "boom"})
+    payload = run_loop.run(orch, "fake", None, None)
+    assert payload["agent_session_degraded"]["degraded"] is True
+    assert "boom" in payload["agent_session_degraded"]["reason"]


### PR DESCRIPTION
## Summary

- 修復 core `copilot_session.py::_resolve_permission_handler` 對 `github-copilot-sdk` 的 API drift：實裝的 0.1.23 中 `PermissionHandler` 是 typing alias（非帶 `approve_all` 的 class），導致每次 session foundation 建立必然 raise → wifi_llapi full-run（`20260704T112950138504`）全 415 案 remediation **silent 降級**到 builtin-fallback，兩輪 full-run 都是事後翻 agent_trace 才發現。
- 改為 feature-detect `PermissionRequestResult`、自組 approve-all permission handler，wire shape 精確為 `{"kind": "approved"}`（0.1.23 為 `TypedDict(total=False)`、無 runtime validation，故測試鎖定形狀防 false-green）。移除舊 `approve_all` 假設，不留雙軌。
- 新增 loud surfacing：run 內第一次 session 建立失敗發**一次性** `log.warning` + `run_loop` 回傳 payload 新增 `agent_session_degraded` key（run-scoped，`run()` 入口 `_reset_run_state()` 重置，避免 reuse 實例洩漏前一次狀態）。

## Release Notes Impact

- Type: fix
- Changelog: updated（`[Unreleased]`）
- Docs impact: none（純內部行為修復，無 operator-facing 介面變動）
- CLI help sync: not affected

## Validation

- 針對性測試綠：`test_copilot_session.py` + `test_orchestrator_session_degraded.py`(3) + `test_run_loop_session_degraded.py`(2) = **12 passed**。
- 全套件：**558 passed，1 failed** = pre-existing `test_offline_creates_wrapper`（cp311/cp312 offline-bundle ABI 不符，與本 PR 三檔零關聯，已對照確認）。
- 真 SDK smoke（`github-copilot-sdk 0.1.23`）：`_resolve_permission_handler()` 回 `{'kind': 'approved'}`，不 raise。
- code review（無 Critical/Important）+ 修掉一個 Minor（degraded 旗標改 run-scoped 重置）。
- 註：`policy_check` 唯一 fail 為 R-07（VERSION 0.3.3 對不上 latest tag v0.3.2），屬 **base main 既存狀態**（0.3.3 unreleased 尚未打 tag），非本 PR 引入、非本 PR 責任（release governance 層，須以 main 上補打 v0.3.3 tag 解決）。
- 真機 end-to-end（下輪 wifi run 的 agent_trace `session_handle.status == "created"`）為 merge 後 follow-up，不 block review。

Closes #16

## Checklist

- [x] Linked issue / problem statement is captured
- [x] `CHANGELOG.md` is updated for user-facing changes, or I explained why it is not needed
- [x] `README.md`, `docs/release-flow.md`, and/or `AGENTS.md` are updated when operator-facing behavior changed（無 operator-facing 變動，不需）
- [x] `VERSION`, `pyproject.toml`, and `src/testpilot/__init__.py` were updated if this is a release-prep PR（非 release-prep）
- [x] README CLI help marker blocks declared in `.project-policy.yml` were refreshed when CLI help changed（CLI 未變）
- [x] Managed install/update/verify-install behavior was reviewed for release-impacting changes（未涉及）
- [x] Release workflow and policy checks were reviewed for release-prep PRs（R-07 為既存 main 狀態，見 Validation）
- [x] Validation is recorded above
- [x] Release tag / release-notes impact was reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
