### PR TITLE
feat(reporting): HTML hybrid summary 對齊 xlsx——位置/分色/TOTAL/隱藏空 Other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ preparation.
 ### Added
 - 可運行的最小 sample plugin `examples/sample_echo`(獨立 dist `testpilot-sample-echo`,經 `testpilot.plugins` entry-point 被發現、僅依賴 `testpilot.api`、`create_runner`→`run_pipeline` 產出 Pass verdict,含 `register_cli` demo);CI 加真實安裝發現 smoke;dev-guide/README 指向 sample 並修死連結、清 `plugins/wifi_llapi/reports/` 並加 `.gitignore` 防 `plugins/*/reports/` run bundle 再被追蹤(保留 `templates/`;R-21)。對照 #3。
 
+### Changed
+- HTML report 的 WiFi LLAPI Hybrid (tri-band) Summary 版面對齊 xlsx `Summary` sheet:section 移到 KPI/total-case 之下、per-case Summary 表之上;per-band 依 `5G`/`6G`/`2.4G` 分色(列底色 + 左側 3px 色條);每 band 尾端補粗體 **TOTAL** 小計列(取自 `bucket_totals`);隱藏空的 `WiFi.Other` catch-all 列(xlsx 無此欄、真實物件恆對到具體分類;非零時仍顯示並計入 TOTAL)。純 `html_reporter` presentation 層改動,不動 `band_category` 計數邏輯。
+
 ### Fixed
 - copilot session foundation 對齊 github-copilot-sdk 0.1.x（`PermissionHandler.approve_all` 已不存在）：自組 approve-all permission handler（wire shape `{"kind": "approved"}`）；session 建立失敗改為一次性 loud warning + run payload `agent_session_degraded` key，終結 silent builtin-fallback（#16）
 

--- a/changelog.d/feat-html-report-hybrid-summary-layout.md
+++ b/changelog.d/feat-html-report-hybrid-summary-layout.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: reporting
+---
+HTML report 的 WiFi LLAPI Hybrid (tri-band) Summary 版面對齊 xlsx Summary sheet：section 位置移到 KPI/total-case 之下、per-case Summary 表之上；每 band 依 `5G`/`6G`/`2.4G` 分色（列底色 + 左側色條）以利區分；每 band 尾端新增粗體 **TOTAL** 小計列（取自 `bucket_totals`）；隱藏空的 `WiFi.Other` catch-all 列（真實 wifi_llapi 物件恆對到具體分類、Other 恆 0 且 xlsx 無此欄；Other 非零時仍顯示並計入 TOTAL）。

--- a/src/testpilot/reporting/html_reporter.py
+++ b/src/testpilot/reporting/html_reporter.py
@@ -173,6 +173,17 @@ tbody td {
 tbody tr:last-child td { border-bottom: none; }
 tbody tr:hover { background: #fafbfc; }
 td.num { text-align: right; font-variant-numeric: tabular-nums; }
+/* Tri-band hybrid summary: colour rows by band for grouping (5G / 6G / 2.4G) */
+tbody tr.band-5g  { background: #eef4fc; }
+tbody tr.band-6g  { background: #f3eefb; }
+tbody tr.band-24g { background: #fbf5ea; }
+tbody tr.band-5g:hover  { background: #e2edfa; }
+tbody tr.band-6g:hover  { background: #ece2f8; }
+tbody tr.band-24g:hover { background: #f7eeda; }
+tbody tr.band-5g  td:first-child { border-left: 3px solid #4a90d9; }
+tbody tr.band-6g  td:first-child { border-left: 3px solid #8a63d2; }
+tbody tr.band-24g td:first-child { border-left: 3px solid #d9a441; }
+tbody tr.band-total td { font-weight: 700; border-top: 2px solid var(--gray-100); }
 /* Collapsible case details */
 details {
   background: var(--white);
@@ -243,10 +254,12 @@ class HtmlReporter:
         parts: list[str] = []
         parts.append(self._doc_open(meta))
         parts.append(self._kpi_strip(summary))
+        # Hybrid (tri-band) summary sits directly below the KPI/total-case strip
+        # and above the per-case Summary table, mirroring the xlsx Summary sheet.
+        parts.append(self._hybrid_summary_section(summary))
         parts.append(self._summary_table(case_results))
         parts.append(self._timing_section(meta, case_results))
         parts.append(self._suite_summary_section(summary))
-        parts.append(self._hybrid_summary_section(summary))
         parts.append(self._per_case_timing(case_results))
         parts.append(self._case_details(case_results, artifact_dir))
         parts.append(self._doc_close())
@@ -466,31 +479,75 @@ class HtmlReporter:
             "<th>Not Supported</th><th>Skip</th><th>Pass Rate</th>",
             "</tr></thead><tbody>",
         ]
+        band_row_class = {
+            "result_5g": "band-5g",
+            "result_6g": "band-6g",
+            "result_24g": "band-24g",
+        }
+        bucket_totals = summary.get("bucket_totals") or {}
+
+        def _emit_row(band_label, category, data, band_cls, *, total_row=False):
+            cls_names = " ".join(
+                c for c in (band_cls, "band-total" if total_row else "") if c
+            )
+            tr_open = f'<tr class="{cls_names}">' if cls_names else "<tr>"
+            cat_cell = (
+                f"<strong>{_esc(category)}</strong>" if total_row else _esc(category)
+            )
+            lines.append(
+                tr_open
+                + f"<td>{_esc(band_label)}</td><td>{cat_cell}</td>"
+                + f"<td class='num'>{_esc(data.get('total_items', 0))}</td>"
+                + f"<td class='num'>{_esc(data.get('tested_items', 0))}</td>"
+                + f"<td class='num'>{_esc(data.get('pass', 0))}</td>"
+                + f"<td class='num'>{_esc(data.get('fail', 0))}</td>"
+                + f"<td class='num'>{_esc(data.get('to_be_tested', 0))}</td>"
+                + f"<td class='num'>{_esc(data.get('not_supported', 0))}</td>"
+                + f"<td class='num'>{_esc(data.get('skip', 0))}</td>"
+                + f"<td class='num'>{_esc(_format_percent(data.get('pass_rate')))}</td>"
+                + "</tr>"
+            )
+
+        def _emit_total(band_key):
+            total = bucket_totals.get(band_key)
+            if not total:
+                return
+            _emit_row(
+                _BAND_LABELS.get(band_key, band_key),
+                "TOTAL",
+                total,
+                band_row_class.get(band_key, ""),
+                total_row=True,
+            )
+
+        prev_key = None
         for row in band_category:
-            band = _esc(
+            band_key = str(row.get("band_key", ""))
+            # 'WiFi.Other' is the categoriser's catch-all fallback bucket; real
+            # WiFi.* objects always map to a concrete category, so hide the row
+            # when it is empty (it has no xlsx Summary counterpart). Any non-zero
+            # count still rolls into the per-band TOTAL below.
+            if str(row.get("category", "")) == "WiFi.Other" and not row.get(
+                "total_items"
+            ):
+                continue
+            if prev_key is not None and band_key != prev_key:
+                _emit_total(prev_key)
+            band_label = (
                 row.get("band_label")
                 or row.get("band")
                 or row.get("band_key")
                 or ""
             )
-            category = _esc(row.get("category", ""))
-            total = _esc(row.get("total_items", 0))
-            tested = _esc(row.get("tested_items", 0))
-            pass_ = _esc(row.get("pass", 0))
-            fail = _esc(row.get("fail", 0))
-            tbt = _esc(row.get("to_be_tested", 0))
-            ns = _esc(row.get("not_supported", 0))
-            skip = _esc(row.get("skip", 0))
-            pr = _esc(_format_percent(row.get("pass_rate")))
-            lines.append(
-                f"<tr>"
-                f"<td>{band}</td><td>{category}</td>"
-                f"<td class='num'>{total}</td><td class='num'>{tested}</td>"
-                f"<td class='num'>{pass_}</td><td class='num'>{fail}</td>"
-                f"<td class='num'>{tbt}</td><td class='num'>{ns}</td>"
-                f"<td class='num'>{skip}</td><td class='num'>{pr}</td>"
-                f"</tr>"
+            _emit_row(
+                band_label,
+                row.get("category", ""),
+                row,
+                band_row_class.get(band_key, ""),
             )
+            prev_key = band_key
+        if prev_key is not None:
+            _emit_total(prev_key)
         lines.append("</tbody></table>")
         return "\n".join(lines)
 

--- a/tests/test_html_reporter.py
+++ b/tests/test_html_reporter.py
@@ -490,3 +490,89 @@ def test_html_reporter_renders_hybrid_summary(tmp_path: Path) -> None:
     assert "WiFi LLAPI Hybrid Summary" in text
     assert "WiFi.AccessPoint" in text
     assert "To be confirmed" in text
+
+
+# ---------------------------------------------------------------------------
+# Hybrid (tri-band) summary layout: placement, per-band colour, TOTAL row,
+# and hiding of the empty WiFi.Other catch-all row.
+# ---------------------------------------------------------------------------
+
+_HYBRID_SUMMARY_WITH_TOTALS: dict[str, Any] = {
+    "policy_version": "wifi_llapi_summary_v1",
+    "band_category": [
+        {
+            "band_key": "result_5g",
+            "band_label": "5G",
+            "category": "WiFi.AccessPoint",
+            "total_items": 2,
+            "tested_items": 2,
+            "pass": 2,
+            "fail": 0,
+            "to_be_tested": 0,
+            "not_supported": 0,
+            "skip": 0,
+            "pass_rate": 1.0,
+        },
+        {
+            "band_key": "result_5g",
+            "band_label": "5G",
+            "category": "WiFi.Other",
+            "total_items": 0,
+            "tested_items": 0,
+            "pass": 0,
+            "fail": 0,
+            "to_be_tested": 0,
+            "not_supported": 0,
+            "skip": 0,
+            "pass_rate": None,
+        },
+    ],
+    "bucket_totals": {
+        "result_5g": {
+            "band_key": "result_5g",
+            "total_items": 2,
+            "tested_items": 2,
+            "pass": 2,
+            "fail": 0,
+            "to_be_tested": 0,
+            "not_supported": 0,
+            "skip": 0,
+            "pass_rate": 1.0,
+        },
+    },
+    "raw_totals": {},
+    "diagnostic_status": {},
+    "per_case": [],
+}
+
+
+def _render_hybrid(tmp_path: Path) -> str:
+    meta = {**_META, "plugin_summary": _HYBRID_SUMMARY_WITH_TOTALS}
+    out = tmp_path / "report.html"
+    HtmlReporter().generate(_CASES, meta, out)
+    return out.read_text(encoding="utf-8")
+
+
+def test_hybrid_summary_positioned_below_kpi_above_summary_table(tmp_path: Path) -> None:
+    text = _render_hybrid(tmp_path)
+    # anchor on the body markup, not the '.kpi-strip' rule inside <style>
+    kpi = text.index('<div class="kpi-strip">')
+    hybrid = text.index("<h2>WiFi LLAPI Hybrid Summary</h2>")
+    summary_table = text.index("<h2>Summary</h2>")
+    assert kpi < hybrid < summary_table
+
+
+def test_hybrid_summary_rows_carry_band_class(tmp_path: Path) -> None:
+    assert 'class="band-5g"' in _render_hybrid(tmp_path)
+
+
+def test_hybrid_summary_emits_per_band_total_row(tmp_path: Path) -> None:
+    text = _render_hybrid(tmp_path)
+    assert "band-total" in text
+    assert "<strong>TOTAL</strong>" in text
+
+
+def test_hybrid_summary_hides_empty_other_row(tmp_path: Path) -> None:
+    text = _render_hybrid(tmp_path)
+    assert "WiFi.AccessPoint" in text
+    assert "WiFi.Other" not in text


### PR DESCRIPTION
## 摘要

HTML report 的 **WiFi LLAPI Hybrid (tri-band) Summary** 版面對齊 xlsx `Summary` sheet，讓兩份報表結構一致、有共同基準。皆為 `html_reporter.py` 單檔 presentation 層改動，**不動 `band_category` 計數邏輯**。

## 變更

| # | 項目 | 說明 |
|---|------|------|
| 1 | 位置 | Hybrid Summary section 移到 KPI(total-case) 之下、per-case `Summary` 表之上 |
| 2 | 分色 | per-band 依 `5G`(藍)/`6G`(紫)/`2.4G`(琥珀) 分色：列底色 + 左側 3px 色條 |
| 3 | TOTAL | 每 band 尾端新增粗體 **TOTAL** 小計列（取自 `bucket_totals`） |
| 4 | 空 Other | 隱藏空的 `WiFi.Other` catch-all 列（xlsx 無此欄；非零時仍顯示並計入 TOTAL） |

## 測試

`tests/test_html_reporter.py` 新增 4 條回歸（位置 / band class / TOTAL / 隱藏空 Other）；`test_html_reporter` + `test_reporter` 共 **55 passed**。

## 備註

- 真實跑報表使用**已安裝的 testpilot-core**；本 PR merge 後需重裝才會反映於實際 run 產出。
- per-band 計數口徑（Tested 定義 / 744 覆蓋 vs 415 執行 / `WiFi.Other` 是否從 `CATEGORIES` 源頭移除）屬另一條 workstream，不在本 PR 範圍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)