### PR TITLE
feat(core): 傳遞 DUT version manifest 到 run/report metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ preparation.
 
 ### Changed
 - HTML report 的 WiFi LLAPI Hybrid (tri-band) Summary 版面對齊 xlsx `Summary` sheet:section 移到 KPI/total-case 之下、per-case Summary 表之上;per-band 依 `5G`/`6G`/`2.4G` 分色(列底色 + 左側 3px 色條);每 band 尾端補粗體 **TOTAL** 小計列(取自 `bucket_totals`);隱藏空的 `WiFi.Other` catch-all 列(xlsx 無此欄、真實物件恆對到具體分類;非零時仍顯示並計入 TOTAL)。純 `html_reporter` presentation 層改動,不動 `band_category` 計數邏輯。
-- run_loop 啟動時一律擷取 plugin 的 DUT version manifest 並透過 `RunResult.version_manifest` 傳給 downstream reporters；report naming 仍維持 CLI `--dut-fw-ver` 優先、否則取 manifest `git`、再 fallback `DUT-FW-VER`；generic Markdown/HTML reporters 於報告頂部新增預設收合的 `Environment / Versions` 區塊。
+- run_loop 啟動時一律擷取 plugin 的 DUT version manifest 並透過 `RunResult.version_manifest` 傳給 downstream reporters；capture hook 若失敗則 warning 後 fail-soft 續跑、沿用空 manifest fallback。report naming 仍維持 CLI `--dut-fw-ver` 優先、否則取 manifest `git`、再 fallback `DUT-FW-VER`；generic Markdown/HTML reporters 於報告頂部新增預設收合的 `Environment / Versions` 區塊。
 
 ### Fixed
 - copilot session foundation 對齊 github-copilot-sdk 0.1.x（`PermissionHandler.approve_all` 已不存在）：自組 approve-all permission handler（wire shape `{"kind": "approved"}`）；session 建立失敗改為一次性 loud warning + run payload `agent_session_degraded` key，終結 silent builtin-fallback（#16）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ preparation.
 
 ### Changed
 - HTML report 的 WiFi LLAPI Hybrid (tri-band) Summary 版面對齊 xlsx `Summary` sheet:section 移到 KPI/total-case 之下、per-case Summary 表之上;per-band 依 `5G`/`6G`/`2.4G` 分色(列底色 + 左側 3px 色條);每 band 尾端補粗體 **TOTAL** 小計列(取自 `bucket_totals`);隱藏空的 `WiFi.Other` catch-all 列(xlsx 無此欄、真實物件恆對到具體分類;非零時仍顯示並計入 TOTAL)。純 `html_reporter` presentation 層改動,不動 `band_category` 計數邏輯。
+- run_loop 啟動時一律擷取 plugin 的 DUT version manifest 並透過 `RunResult.version_manifest` 傳給 downstream reporters；report naming 仍維持 CLI `--dut-fw-ver` 優先、否則取 manifest `git`、再 fallback `DUT-FW-VER`；generic Markdown/HTML reporters 於報告頂部新增預設收合的 `Environment / Versions` 區塊。
 
 ### Fixed
 - copilot session foundation 對齊 github-copilot-sdk 0.1.x（`PermissionHandler.approve_all` 已不存在）：自組 approve-all permission handler（wire shape `{"kind": "approved"}`）；session 建立失敗改為一次性 loud warning + run payload `agent_session_degraded` key，終結 silent builtin-fallback（#16）

--- a/changelog.d/dut-version-manifest.md
+++ b/changelog.d/dut-version-manifest.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: core
+---
+`run_loop` 無條件呼叫 plugin 的 DUT 版本 capture（fail-soft：擷取失敗記 warning 並以 `{}` 續行、不中止 run），naming 仍以 `--dut-fw-ver` 優先、fallback 取 `manifest["git"]`，整份 manifest 存進 `meta["version_manifest"]`。html/md reporter 於報表頂部渲染收折的 Environment/Versions 區塊（缺資料 no-op、不具名 plugin）。

--- a/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/design.md
+++ b/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The plugin-facing run loop already calls `capture_dut_firmware_version()` for report naming when the CLI does not supply `--dut-fw-ver`. The 2026-07-08 plan changes that contract: plugins will return a full manifest dict, the core loop must always capture it even when naming comes from the CLI, and generic HTML/Markdown reporters should surface the manifest as a collapsed Environment / Versions block near the top of the report.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Capture the plugin version manifest exactly once at run start and store it in `meta["version_manifest"]`.
+- Preserve current naming precedence so `--dut-fw-ver` still wins for the report filename while the manifest is still captured for metadata/reporting.
+- Render a collapsed Environment / Versions section in HTML and Markdown only when the manifest exists.
+- Keep the core implementation plugin-agnostic; the generic layer should know only about the `version_manifest` metadata key.
+
+**Non-Goals:**
+- Defining the manifest field list or DUT command parsing logic; that remains plugin-owned.
+- Modifying XLSX report generation, which is wifi_llapi-specific.
+- Introducing new plugin hooks or changing case-execution semantics outside the run-start capture path.
+
+## Decisions
+
+1. **Unconditional manifest capture**
+   - `run_loop` will call the plugin hook even when the CLI provided `--dut-fw-ver`.
+   - The naming helper will continue to prefer the CLI argument, but the captured manifest is always stored in metadata for downstream reporters.
+
+2. **String naming derives from manifest `git` field**
+   - When no CLI override exists, the core loop uses `manifest.get("git", "")` as the report firmware string.
+   - This keeps backward-compatible naming semantics while allowing the hook return type to evolve from `str` to `dict`.
+
+3. **Generic reporters render a no-op-when-absent details block**
+   - HTML and Markdown reporters will add the Environment / Versions section immediately after the header and before KPI/summary sections.
+   - If `version_manifest` is missing or empty, reporters leave existing output unchanged.
+
+4. **Plugin-neutral metadata contract**
+   - The core layer will use only `meta["version_manifest"]` and generic labels such as "Environment / Versions".
+   - No `wifi_llapi` string or plugin-specific field assumptions beyond iterating the provided mapping are introduced in the shared reporters.
+
+## Risks / Trade-offs
+
+- **Hook return type drift across repos** → verify wifi_llapi against the core worktree editable install and land both PRs together.
+- **Generic reporter clutter** → keep the section collapsed by default and skip it entirely when metadata is absent.
+- **Malformed plugin metadata** → the core loop/reporter path should guard shape checks and degrade to a no-op instead of crashing report generation.

--- a/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/proposal.md
+++ b/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+testpilot-core currently treats the firmware hook as a naming-only string source and generic reporters do not surface the richer DUT environment context operators need when triaging wifi_llapi runs. We need the core loop and generic report projectors to carry a full version manifest so plugin-specific report logic can rely on a stable runtime contract and human-readable reports show the captured environment directly.
+
+## What Changes
+
+- Update the core run loop to capture the plugin's DUT version manifest once at run start, store it in run metadata, and keep CLI firmware overrides limited to naming resolution.
+- Render a collapsed Environment / Versions block at the top of HTML and Markdown reports when a version manifest is present.
+- Add tests that lock the run-loop metadata contract and the new report projection behavior.
+
+## Capabilities
+
+### New Capabilities
+- `dut-version-manifest-reporting`: Propagate a plugin-provided DUT version manifest through the core run loop and generic report outputs.
+
+### Modified Capabilities
+
+## Impact
+
+- `src/testpilot/core/run_loop.py`
+- `src/testpilot/reporting/html_reporter.py`
+- `src/testpilot/reporting/reporter.py`
+- `tests/test_run_loop*.py`
+- `tests/test_html_reporter.py`
+- `tests/test_reporter.py`
+- `CHANGELOG.md` and directly related docs/OpenSpec artifacts

--- a/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/specs/dut-version-manifest-reporting/spec.md
+++ b/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/specs/dut-version-manifest-reporting/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: the core run loop SHALL persist a plugin-provided DUT version manifest
+The core run loop SHALL capture the plugin-provided DUT version manifest once at run start and store it in `meta["version_manifest"]` for downstream reporting. The run loop SHALL continue to honor `--dut-fw-ver` as the preferred report-naming string, but it MUST still capture and persist the manifest even when the CLI override is present.
+
+#### Scenario: no CLI override uses manifest git for naming
+- **WHEN** a plugin returns a version manifest with `git` populated and the run does not specify `--dut-fw-ver`
+- **THEN** the run metadata stores the full manifest and the report firmware naming string comes from `version_manifest["git"]`
+
+#### Scenario: CLI override still captures manifest
+- **WHEN** a run specifies `--dut-fw-ver` and the plugin returns a version manifest
+- **THEN** the report naming string uses the CLI value and `meta["version_manifest"]` still contains the captured manifest
+
+### Requirement: generic reporters SHALL render a collapsed Environment / Versions section
+HTML and Markdown report generators SHALL render a collapsed Environment / Versions section near the top of the report when `meta["version_manifest"]` is present and non-empty. The section SHALL list the captured manifest fields without requiring plugin-specific rendering logic, and reporters MUST leave existing output unchanged when the manifest is absent.
+
+#### Scenario: manifest present renders collapsed section
+- **WHEN** report generation receives metadata containing a non-empty `version_manifest`
+- **THEN** the HTML and Markdown outputs include a collapsed Environment / Versions block before the KPI or suite-summary sections
+
+#### Scenario: manifest absent is a no-op
+- **WHEN** report generation receives metadata without `version_manifest`
+- **THEN** the reporters do not emit an Environment / Versions block and continue producing the existing report structure

--- a/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/tasks.md
+++ b/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Run-loop metadata propagation
 
-- [ ] 1.1 Update the core run loop to capture the plugin version manifest unconditionally, preserve CLI naming precedence, and store the manifest in run metadata.
-- [ ] 1.2 Add focused pytest coverage for the manifest metadata contract and naming fallback behavior.
+- [x] 1.1 Update the core run loop to capture the plugin version manifest unconditionally, preserve CLI naming precedence, and store the manifest in run metadata.
+- [x] 1.2 Add focused pytest coverage for the manifest metadata contract and naming fallback behavior.
 
 ## 2. Generic report rendering
 
-- [ ] 2.1 Render a collapsed Environment / Versions block at the top of HTML and Markdown reports when `version_manifest` metadata is present.
-- [ ] 2.2 Add reporter tests that verify the collapsed section content and the no-op behavior when the manifest is absent.
+- [x] 2.1 Render a collapsed Environment / Versions block at the top of HTML and Markdown reports when `version_manifest` metadata is present.
+- [x] 2.2 Add reporter tests that verify the collapsed section content and the no-op behavior when the manifest is absent.
 
 ## 3. Delivery and verification
 
-- [ ] 3.1 Sync the repo changelog/OpenSpec/docs impacted by the new reporting contract.
-- [ ] 3.2 Run the targeted and full repo verification needed for the cross-repo landing.
+- [x] 3.1 Sync the repo changelog/OpenSpec/docs impacted by the new reporting contract.
+- [x] 3.2 Run the targeted and full repo verification needed for the cross-repo landing.

--- a/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/tasks.md
+++ b/openspec/changes/archive/2026-07-08-dut-version-manifest-report-alignment/tasks.md
@@ -1,0 +1,14 @@
+## 1. Run-loop metadata propagation
+
+- [ ] 1.1 Update the core run loop to capture the plugin version manifest unconditionally, preserve CLI naming precedence, and store the manifest in run metadata.
+- [ ] 1.2 Add focused pytest coverage for the manifest metadata contract and naming fallback behavior.
+
+## 2. Generic report rendering
+
+- [ ] 2.1 Render a collapsed Environment / Versions block at the top of HTML and Markdown reports when `version_manifest` metadata is present.
+- [ ] 2.2 Add reporter tests that verify the collapsed section content and the no-op behavior when the manifest is absent.
+
+## 3. Delivery and verification
+
+- [ ] 3.1 Sync the repo changelog/OpenSpec/docs impacted by the new reporting contract.
+- [ ] 3.2 Run the targeted and full repo verification needed for the cross-repo landing.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/specs/dut-version-manifest-reporting/spec.md
+++ b/openspec/specs/dut-version-manifest-reporting/spec.md
@@ -1,0 +1,27 @@
+# dut-version-manifest-reporting Specification
+
+## Purpose
+TBD - created by archiving change dut-version-manifest-report-alignment. Update Purpose after archive.
+## Requirements
+### Requirement: the core run loop SHALL persist a plugin-provided DUT version manifest
+The core run loop SHALL capture the plugin-provided DUT version manifest once at run start and store it in `meta["version_manifest"]` for downstream reporting. The run loop SHALL continue to honor `--dut-fw-ver` as the preferred report-naming string, but it MUST still capture and persist the manifest even when the CLI override is present.
+
+#### Scenario: no CLI override uses manifest git for naming
+- **WHEN** a plugin returns a version manifest with `git` populated and the run does not specify `--dut-fw-ver`
+- **THEN** the run metadata stores the full manifest and the report firmware naming string comes from `version_manifest["git"]`
+
+#### Scenario: CLI override still captures manifest
+- **WHEN** a run specifies `--dut-fw-ver` and the plugin returns a version manifest
+- **THEN** the report naming string uses the CLI value and `meta["version_manifest"]` still contains the captured manifest
+
+### Requirement: generic reporters SHALL render a collapsed Environment / Versions section
+HTML and Markdown report generators SHALL render a collapsed Environment / Versions section near the top of the report when `meta["version_manifest"]` is present and non-empty. The section SHALL list the captured manifest fields without requiring plugin-specific rendering logic, and reporters MUST leave existing output unchanged when the manifest is absent.
+
+#### Scenario: manifest present renders collapsed section
+- **WHEN** report generation receives metadata containing a non-empty `version_manifest`
+- **THEN** the HTML and Markdown outputs include a collapsed Environment / Versions block before the KPI or suite-summary sections
+
+#### Scenario: manifest absent is a no-op
+- **WHEN** report generation receives metadata without `version_manifest`
+- **THEN** the reporters do not emit an Environment / Versions block and continue producing the existing report structure
+

--- a/openspec/specs/dut-version-manifest-reporting/spec.md
+++ b/openspec/specs/dut-version-manifest-reporting/spec.md
@@ -1,7 +1,8 @@
 # dut-version-manifest-reporting Specification
 
 ## Purpose
-TBD - created by archiving change dut-version-manifest-report-alignment. Update Purpose after archive.
+Define the core run-loop DUT version manifest propagation contract and the
+generic Environment / Versions rendering used by downstream reporters.
 ## Requirements
 ### Requirement: the core run loop SHALL persist a plugin-provided DUT version manifest
 The core run loop SHALL capture the plugin-provided DUT version manifest once at run start and store it in `meta["version_manifest"]` for downstream reporting. The run loop SHALL continue to honor `--dut-fw-ver` as the preferred report-naming string, but it MUST still capture and persist the manifest even when the CLI override is present.
@@ -24,4 +25,3 @@ HTML and Markdown report generators SHALL render a collapsed Environment / Versi
 #### Scenario: manifest absent is a no-op
 - **WHEN** report generation receives metadata without `version_manifest`
 - **THEN** the reporters do not emit an Environment / Versions block and continue producing the existing report structure
-

--- a/src/testpilot/core/run_loop.py
+++ b/src/testpilot/core/run_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
 import logging
@@ -60,21 +61,38 @@ class RunResult:
     first_case_started_monotonic: float | None = None
     first_case_started_at_iso: str = ""
     artifacts: dict[str, Any] = field(default_factory=dict)
-def _resolve_firmware_version(
+    version_manifest: dict[str, Any] = field(default_factory=dict)
+
+
+def _capture_version_manifest(
     orchestrator: Any,
     *,
     plugin: Any,
     cases: list[dict[str, Any]],
+) -> dict[str, Any]:
+    capture = getattr(plugin, "capture_dut_firmware_version", None)
+    if not callable(capture):
+        return {}
+    captured = capture(getattr(orchestrator, "config", None), cases)
+    if isinstance(captured, Mapping):
+        return dict(captured)
+    legacy_git = str(captured or "").strip()
+    if legacy_git:
+        return {"git": legacy_git}
+    return {}
+
+
+def _resolve_firmware_version(
+    *,
     requested: str | None,
+    version_manifest: Mapping[str, Any],
 ) -> tuple[str, str]:
     requested_value = (requested or "").strip()
     if requested_value and requested_value != "DUT-FW-VER":
         return requested_value, "cli"
-    capture = getattr(plugin, "capture_dut_firmware_version", None)
-    if callable(capture):
-        captured = str(capture(orchestrator.config, cases) or "").strip()
-        if captured:
-            return captured, "dut_git_revision"
+    manifest_git = str(version_manifest.get("git", "") or "").strip()
+    if manifest_git:
+        return manifest_git, "dut_git_revision"
     return "DUT-FW-VER", "fallback_default"
 
 
@@ -194,6 +212,11 @@ def run(
     reports_root = Path(orchestrator.plugins_dir) / plugin_name / "reports"
     run_date = date.today()
     run_id = datetime.now().strftime("%Y%m%dT%H%M%S%f")
+    version_manifest = _capture_version_manifest(
+        orchestrator,
+        plugin=plugin,
+        cases=cases,
+    )
 
     capture_path = orchestrator._start_run_capture(run_id)
     run_handle = _seq_tracking_handle(
@@ -204,10 +227,8 @@ def run(
     run_seq_start = _mark_seq_position(orchestrator, run_handle)
 
     fw_ver, fw_ver_source = _resolve_firmware_version(
-        orchestrator,
-        plugin=plugin,
-        cases=cases,
         requested=dut_fw_ver,
+        version_manifest=version_manifest,
     )
     artifact_dir = reports_root / run_id
     artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -362,6 +383,7 @@ def run(
         first_case_started_monotonic=first_case_started_monotonic,
         first_case_started_at_iso=first_case_started_at_iso,
         artifacts=prepared_artifacts,
+        version_manifest=version_manifest,
     )
 
     reporter = plugin.create_reporter()

--- a/src/testpilot/core/run_loop.py
+++ b/src/testpilot/core/run_loop.py
@@ -73,7 +73,15 @@ def _capture_version_manifest(
     capture = getattr(plugin, "capture_dut_firmware_version", None)
     if not callable(capture):
         return {}
-    captured = capture(getattr(orchestrator, "config", None), cases)
+    try:
+        captured = capture(getattr(orchestrator, "config", None), cases)
+    except Exception:
+        log.warning(
+            "%s version manifest capture failed; continuing without manifest",
+            getattr(plugin, "name", "plugin"),
+            exc_info=True,
+        )
+        return {}
     if isinstance(captured, Mapping):
         return dict(captured)
     legacy_git = str(captured or "").strip()

--- a/src/testpilot/core/run_loop.py
+++ b/src/testpilot/core/run_loop.py
@@ -220,12 +220,6 @@ def run(
     reports_root = Path(orchestrator.plugins_dir) / plugin_name / "reports"
     run_date = date.today()
     run_id = datetime.now().strftime("%Y%m%dT%H%M%S%f")
-    version_manifest = _capture_version_manifest(
-        orchestrator,
-        plugin=plugin,
-        cases=cases,
-    )
-
     capture_path = orchestrator._start_run_capture(run_id)
     run_handle = _seq_tracking_handle(
         orchestrator,
@@ -233,6 +227,11 @@ def run(
         capture_path=capture_path,
     )
     run_seq_start = _mark_seq_position(orchestrator, run_handle)
+    version_manifest = _capture_version_manifest(
+        orchestrator,
+        plugin=plugin,
+        cases=cases,
+    )
 
     fw_ver, fw_ver_source = _resolve_firmware_version(
         requested=dut_fw_ver,

--- a/src/testpilot/reporting/html_reporter.py
+++ b/src/testpilot/reporting/html_reporter.py
@@ -20,6 +20,7 @@ from testpilot.reporting.reporter import (
     _overall_status,
     _suite_timing_rows,
     _summary_payload,
+    _version_manifest_rows,
 )
 
 # ---------------------------------------------------------------------------
@@ -225,6 +226,12 @@ pre.code-block {
 }
 .detail-meta { font-size: 13px; color: var(--gray-600); margin-bottom: 8px; }
 .detail-meta strong { color: var(--graphite-800); }
+.environment-versions { margin-bottom: 24px; }
+.environment-versions ul {
+  margin: 0;
+  padding: 16px 16px 16px 32px;
+}
+.environment-versions li + li { margin-top: 8px; }
 /* Responsive */
 @media (max-width: 600px) {
   .kpi-strip { flex-direction: column; }
@@ -253,6 +260,7 @@ class HtmlReporter:
         artifact_dir = output_path.parent
         parts: list[str] = []
         parts.append(self._doc_open(meta))
+        parts.append(self._version_manifest_section(meta))
         parts.append(self._kpi_strip(summary))
         # Hybrid (tri-band) summary sits directly below the KPI/total-case strip
         # and above the per-case Summary table, mirroring the xlsx Summary sheet.
@@ -371,6 +379,24 @@ class HtmlReporter:
             )
         parts.append("</div>")
         return "\n".join(parts)
+
+    @staticmethod
+    def _version_manifest_section(meta: Mapping[str, Any]) -> str:
+        rows = _version_manifest_rows(meta)
+        if not rows:
+            return ""
+        lines = [
+            '<details class="environment-versions">',
+            "<summary>Environment / Versions</summary>",
+            '<div class="detail-body">',
+            "<ul>",
+        ]
+        for key, value in rows:
+            lines.append(
+                f"<li><strong>{_esc(key)}</strong>: <code>{_esc(value)}</code></li>"
+            )
+        lines.extend(["</ul>", "</div>", "</details>"])
+        return "\n".join(lines)
 
     # -- summary table ------------------------------------------------------
 

--- a/src/testpilot/reporting/reporter.py
+++ b/src/testpilot/reporting/reporter.py
@@ -74,10 +74,19 @@ def _precomputed_plugin_summary(
 
 
 def _stringify_manifest_value(value: Any) -> str:
-    if isinstance(value, MappingABC):
-        return json.dumps(dict(value), ensure_ascii=False, default=str)
-    if isinstance(value, SequenceABC) and not isinstance(value, (str, bytes, bytearray)):
-        return json.dumps(list(value), ensure_ascii=False, default=str)
+    # version_manifest comes from a plugin (unenforced shape); a non-JSON-
+    # serializable value/key must never crash the whole report -> fail-soft.
+    try:
+        if isinstance(value, MappingABC):
+            return json.dumps(
+                {str(key): item for key, item in value.items()},
+                ensure_ascii=False,
+                default=str,
+            )
+        if isinstance(value, SequenceABC) and not isinstance(value, (str, bytes, bytearray)):
+            return json.dumps(list(value), ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)
     return str(value)
 
 

--- a/src/testpilot/reporting/reporter.py
+++ b/src/testpilot/reporting/reporter.py
@@ -6,6 +6,7 @@ Provides :class:`IReporter` protocol plus concrete
 
 from __future__ import annotations
 
+from collections.abc import Mapping as MappingABC, Sequence as SequenceABC
 import json
 from collections import Counter
 from datetime import datetime, timezone
@@ -70,6 +71,24 @@ def _precomputed_plugin_summary(
     if isinstance(val, dict):
         return dict(val)
     return None
+
+
+def _stringify_manifest_value(value: Any) -> str:
+    if isinstance(value, MappingABC):
+        return json.dumps(dict(value), ensure_ascii=False, default=str)
+    if isinstance(value, SequenceABC) and not isinstance(value, (str, bytes, bytearray)):
+        return json.dumps(list(value), ensure_ascii=False, default=str)
+    return str(value)
+
+
+def _version_manifest_rows(meta: Mapping[str, Any]) -> list[tuple[str, str]]:
+    manifest = meta.get("version_manifest")
+    if not isinstance(manifest, MappingABC) or not manifest:
+        return []
+    return [
+        (str(key), _stringify_manifest_value(value))
+        for key, value in manifest.items()
+    ]
 
 
 def _summary_payload(
@@ -235,6 +254,7 @@ class MarkdownReporter:
         lines: list[str] = []
         summary = _summary_payload(case_results, meta)
         self._write_header(lines, meta)
+        self._write_version_manifest(lines, meta)
         self._write_timing(lines, meta, case_results)
         self._write_suite_summary(lines, summary)
         self._write_hybrid_summary(lines, summary)
@@ -257,6 +277,19 @@ class MarkdownReporter:
             if key in meta:
                 label = key.replace("_", " ").title()
                 lines.append(f"- **{label}**: {meta[key]}")
+        lines.append("")
+
+    @staticmethod
+    def _write_version_manifest(lines: list[str], meta: Mapping[str, Any]) -> None:
+        rows = _version_manifest_rows(meta)
+        if not rows:
+            return
+        lines.append("<details><summary>Environment / Versions</summary>")
+        lines.append("")
+        for key, value in rows:
+            lines.append(f"- **{key}**: `{value}`")
+        lines.append("")
+        lines.append("</details>")
         lines.append("")
 
     @staticmethod

--- a/tests/test_html_reporter.py
+++ b/tests/test_html_reporter.py
@@ -224,6 +224,34 @@ class TestHtmlReporter:
         HtmlReporter().generate(_CASES, _META, out)
         assert out.exists()
 
+    def test_renders_collapsed_environment_versions_block(self, tmp_path: Path) -> None:
+        out = tmp_path / "report.html"
+        meta = {
+            **_META,
+            "version_manifest": {
+                "git": "deadbeef",
+                "build": "2026.07.08",
+                "components": {"wifi": "1.2.3"},
+            },
+        }
+
+        HtmlReporter().generate(_CASES, meta, out)
+
+        text = out.read_text(encoding="utf-8")
+        assert '<details class="environment-versions">' in text
+        assert "<summary>Environment / Versions</summary>" in text
+        assert "<strong>git</strong>" in text
+        assert "deadbeef" in text
+        assert "{&quot;wifi&quot;: &quot;1.2.3&quot;}" in text
+        assert text.index("Environment / Versions") < text.index("Total Cases")
+        assert '<details class="environment-versions" open>' not in text
+
+    def test_omits_environment_versions_block_when_manifest_missing(self, tmp_path: Path) -> None:
+        out = tmp_path / "report.html"
+        HtmlReporter().generate(_CASES, _META, out)
+        text = out.read_text(encoding="utf-8")
+        assert "Environment / Versions" not in text
+
 
 # ---------------------------------------------------------------------------
 # HTML escaping / security

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -146,6 +146,32 @@ class TestMarkdownReporter:
         MarkdownReporter().generate(_CASES, _META, out)
         assert out.exists()
 
+    def test_renders_collapsed_environment_versions_block(self, tmp_path: Path) -> None:
+        out = tmp_path / "report.md"
+        meta = {
+            **_META,
+            "version_manifest": {
+                "git": "deadbeef",
+                "build": "2026.07.08",
+                "components": {"wifi": "1.2.3"},
+            },
+        }
+
+        MarkdownReporter().generate(_CASES, meta, out)
+
+        text = out.read_text(encoding="utf-8")
+        assert "<details><summary>Environment / Versions</summary>" in text
+        assert "- **git**: `deadbeef`" in text
+        assert '- **components**: `{"wifi": "1.2.3"}`' in text
+        assert text.index("<details><summary>Environment / Versions</summary>") < text.index("## Timing")
+        assert "<details open>" not in text
+
+    def test_omits_environment_versions_block_when_manifest_missing(self, tmp_path: Path) -> None:
+        out = tmp_path / "report.md"
+        MarkdownReporter().generate(_CASES, _META, out)
+        text = out.read_text(encoding="utf-8")
+        assert "Environment / Versions" not in text
+
 
 # ---------------------------------------------------------------------------
 # JsonReporter

--- a/tests/test_run_loop_session_degraded.py
+++ b/tests/test_run_loop_session_degraded.py
@@ -34,8 +34,14 @@ class _FakePlugin:
     version = "0.1.0"
     name = "fake"
 
-    def __init__(self, captured_version: Any = None) -> None:
+    def __init__(
+        self,
+        captured_version: Any = None,
+        *,
+        capture_exception: Exception | None = None,
+    ) -> None:
         self.captured_version = captured_version
+        self.capture_exception = capture_exception
         self.capture_calls = 0
 
     def prepare_run(self, case_ids: Any) -> PreparedRun:
@@ -47,6 +53,8 @@ class _FakePlugin:
     def capture_dut_firmware_version(self, config: Any, cases: Any) -> Any:
         del config, cases
         self.capture_calls += 1
+        if self.capture_exception is not None:
+            raise self.capture_exception
         return self.captured_version
 
     def create_reporter(self) -> _FakeReporter:
@@ -180,3 +188,47 @@ def test_run_payload_normalizes_legacy_string_version_manifest(tmp_path: Path) -
     assert payload["fw_ver"] == "legacy-git-sha"
     assert payload["fw_ver_source"] == "dut_git_revision"
     assert payload["version_manifest"] == {"git": "legacy-git-sha"}
+
+
+def test_run_payload_fails_soft_when_manifest_capture_raises_with_cli_override(
+    tmp_path: Path,
+    caplog: Any,
+) -> None:
+    plugin = _FakePlugin(
+        capture_exception=RuntimeError("capture boom"),
+    )
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+    )
+
+    payload = run_loop.run(orch, "fake", None, "cli-fw-123")
+
+    assert plugin.capture_calls == 1
+    assert payload["fw_ver"] == "cli-fw-123"
+    assert payload["fw_ver_source"] == "cli"
+    assert payload["version_manifest"] == {}
+    assert "version manifest capture failed" in caplog.text
+
+
+def test_run_payload_fails_soft_when_manifest_capture_raises_without_cli_override(
+    tmp_path: Path,
+    caplog: Any,
+) -> None:
+    plugin = _FakePlugin(
+        capture_exception=RuntimeError("capture boom"),
+    )
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+    )
+
+    payload = run_loop.run(orch, "fake", None, None)
+
+    assert plugin.capture_calls == 1
+    assert payload["fw_ver"] == "DUT-FW-VER"
+    assert payload["fw_ver_source"] == "fallback_default"
+    assert payload["version_manifest"] == {}
+    assert "version manifest capture failed" in caplog.text

--- a/tests/test_run_loop_session_degraded.py
+++ b/tests/test_run_loop_session_degraded.py
@@ -21,18 +21,33 @@ from testpilot.core.prepared_run import PreparedRun
 
 class _FakeReporter:
     def build_reports(self, run_result: Any) -> dict[str, Any]:
-        return {"status": "ok", "cases_count": run_result.cases_count}
+        return {
+            "status": "ok",
+            "cases_count": run_result.cases_count,
+            "fw_ver": run_result.fw_ver,
+            "fw_ver_source": run_result.fw_ver_source,
+            "version_manifest": dict(run_result.version_manifest),
+        }
 
 
 class _FakePlugin:
     version = "0.1.0"
     name = "fake"
 
+    def __init__(self, captured_version: Any = None) -> None:
+        self.captured_version = captured_version
+        self.capture_calls = 0
+
     def prepare_run(self, case_ids: Any) -> PreparedRun:
         return PreparedRun(cases=[], artifacts={})
 
     def execution_policy(self, case: Any) -> dict[str, Any]:
         return {}
+
+    def capture_dut_firmware_version(self, config: Any, cases: Any) -> Any:
+        del config, cases
+        self.capture_calls += 1
+        return self.captured_version
 
     def create_reporter(self) -> _FakeReporter:
         return _FakeReporter()
@@ -62,9 +77,16 @@ class _FakeRunnerSelector:
 class _StubOrchestrator:
     """Minimal orchestrator surface exercised by run_loop.run with zero cases."""
 
-    def __init__(self, plugins_dir: Path, degraded: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        plugins_dir: Path,
+        degraded: dict[str, Any],
+        *,
+        plugin: _FakePlugin | None = None,
+    ) -> None:
         self.plugins_dir = plugins_dir
-        self.loader = _FakeLoader(_FakePlugin())
+        self.config = {}
+        self.loader = _FakeLoader(plugin or _FakePlugin())
         self.run_backend = _FakeRunBackend()
         self.runner_selector = _FakeRunnerSelector()
         self.run_handle = None
@@ -96,3 +118,65 @@ def test_run_payload_degraded_true_when_sessions_fail(tmp_path: Path) -> None:
     payload = run_loop.run(orch, "fake", None, None)
     assert payload["agent_session_degraded"]["degraded"] is True
     assert "boom" in payload["agent_session_degraded"]["reason"]
+
+
+def test_run_payload_uses_manifest_git_for_naming_and_metadata(tmp_path: Path) -> None:
+    plugin = _FakePlugin({"git": "deadbeef", "image": "BGW720"})
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+    )
+
+    payload = run_loop.run(orch, "fake", None, None)
+
+    assert plugin.capture_calls == 1
+    assert payload["fw_ver"] == "deadbeef"
+    assert payload["fw_ver_source"] == "dut_git_revision"
+    assert payload["version_manifest"] == {"git": "deadbeef", "image": "BGW720"}
+
+
+def test_run_payload_preserves_manifest_when_cli_fw_ver_wins_naming(tmp_path: Path) -> None:
+    plugin = _FakePlugin({"git": "deadbeef", "image": "BGW720"})
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+    )
+
+    payload = run_loop.run(orch, "fake", None, "cli-fw-123")
+
+    assert plugin.capture_calls == 1
+    assert payload["fw_ver"] == "cli-fw-123"
+    assert payload["fw_ver_source"] == "cli"
+    assert payload["version_manifest"] == {"git": "deadbeef", "image": "BGW720"}
+
+
+def test_run_payload_falls_back_when_manifest_has_no_git(tmp_path: Path) -> None:
+    plugin = _FakePlugin({"build": "2026.07.08"})
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+    )
+
+    payload = run_loop.run(orch, "fake", None, None)
+
+    assert payload["fw_ver"] == "DUT-FW-VER"
+    assert payload["fw_ver_source"] == "fallback_default"
+    assert payload["version_manifest"] == {"build": "2026.07.08"}
+
+
+def test_run_payload_normalizes_legacy_string_version_manifest(tmp_path: Path) -> None:
+    plugin = _FakePlugin("legacy-git-sha")
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+    )
+
+    payload = run_loop.run(orch, "fake", None, None)
+
+    assert payload["fw_ver"] == "legacy-git-sha"
+    assert payload["fw_ver_source"] == "dut_git_revision"
+    assert payload["version_manifest"] == {"git": "legacy-git-sha"}

--- a/tests/test_run_loop_session_degraded.py
+++ b/tests/test_run_loop_session_degraded.py
@@ -39,10 +39,12 @@ class _FakePlugin:
         captured_version: Any = None,
         *,
         capture_exception: Exception | None = None,
+        events: list[str] | None = None,
     ) -> None:
         self.captured_version = captured_version
         self.capture_exception = capture_exception
         self.capture_calls = 0
+        self.events = events
 
     def prepare_run(self, case_ids: Any) -> PreparedRun:
         return PreparedRun(cases=[], artifacts={})
@@ -53,6 +55,8 @@ class _FakePlugin:
     def capture_dut_firmware_version(self, config: Any, cases: Any) -> Any:
         del config, cases
         self.capture_calls += 1
+        if self.events is not None:
+            self.events.append("capture_version_manifest")
         if self.capture_exception is not None:
             raise self.capture_exception
         return self.captured_version
@@ -91,6 +95,7 @@ class _StubOrchestrator:
         degraded: dict[str, Any],
         *,
         plugin: _FakePlugin | None = None,
+        events: list[str] | None = None,
     ) -> None:
         self.plugins_dir = plugins_dir
         self.config = {}
@@ -99,8 +104,12 @@ class _StubOrchestrator:
         self.runner_selector = _FakeRunnerSelector()
         self.run_handle = None
         self.agent_session_degraded = degraded
+        self.events = events
 
     def _start_run_capture(self, run_id: str) -> Path | None:
+        del run_id
+        if self.events is not None:
+            self.events.append("start_run_capture")
         return None
 
     def _stop_run_capture(self) -> None:
@@ -142,6 +151,21 @@ def test_run_payload_uses_manifest_git_for_naming_and_metadata(tmp_path: Path) -
     assert payload["fw_ver"] == "deadbeef"
     assert payload["fw_ver_source"] == "dut_git_revision"
     assert payload["version_manifest"] == {"git": "deadbeef", "image": "BGW720"}
+
+
+def test_run_starts_capture_before_version_manifest_probe(tmp_path: Path) -> None:
+    events: list[str] = []
+    plugin = _FakePlugin({"git": "deadbeef"}, events=events)
+    orch = _StubOrchestrator(
+        tmp_path,
+        {"degraded": False, "reason": ""},
+        plugin=plugin,
+        events=events,
+    )
+
+    run_loop.run(orch, "fake", None, None)
+
+    assert events[:2] == ["start_run_capture", "capture_version_manifest"]
 
 
 def test_run_payload_preserves_manifest_when_cli_fw_ver_wins_naming(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- 依 `testpilot/docs/superpowers/plans/2026-07-08-dut-version-manifest.md` 的跨 repo 設計，補上 core run loop 的 DUT version manifest 擷取與傳遞契約。
- `--dut-fw-ver` 保持 report naming precedence，同時無論是否有 CLI override 都會把完整 `version_manifest` 帶進 `RunResult` / report metadata。
- generic Markdown / HTML reporter 新增 collapsed `Environment / Versions` 區塊，避免 plugin-specific renderer duplication。
- OpenSpec change `dut-version-manifest-report-alignment` 已 archive。

## Release Notes Impact

- Type: feature
- Changelog: updated
- Docs impact: none
- CLI help sync: not affected

## Validation

- `uv run pytest -q`
- `python3 -m policy_check --repo .`

## Checklist

- [x] Linked issue / problem statement is captured
- [x] `CHANGELOG.md` is updated for user-facing changes, or I explained why it is not needed
- [x] `README.md`, `docs/release-flow.md`, and/or `AGENTS.md` are updated when operator-facing behavior changed
- [x] `VERSION`, `pyproject.toml`, and `src/testpilot/__init__.py` were updated if this is a release-prep PR
- [x] README CLI help marker blocks declared in `.project-policy.yml` were refreshed when CLI help changed
- [x] Managed install/update/verify-install behavior was reviewed for release-impacting changes
- [x] Release workflow and policy checks were reviewed for release-prep PRs
- [x] Validation is recorded above
- [x] Release tag / release-notes impact was reviewed
