### PR TITLE
fix(reporting): md 報表 Hybrid summary 對齊 html — 空 WiFi.Other 改顯示該 band TOTAL 匯總

### DIFF
--- a/changelog.d/fix-md-report-hybrid-summary-align.md
+++ b/changelog.d/fix-md-report-hybrid-summary-align.md
@@ -1,0 +1,6 @@
+---
+type: fix
+scope: reporting
+---
+
+Markdown 報表的 WiFi LLAPI Hybrid summary 表對齊 HTML 報表：空的 `WiFi.Other` catch-all 列（無 xlsx Summary 對應）改以該 band 的 **TOTAL 匯總列**呈現（取自 `bucket_totals`，統計該 band 全 category 總數），非只顯示 WiFi.Other 的 0。先前只修了 `html_reporter`（見 `feat-html-report-hybrid-summary-layout`），`reporter`(md) 未同步，本次補齊使兩者逐列一致。

--- a/src/testpilot/reporting/reporter.py
+++ b/src/testpilot/reporting/reporter.py
@@ -324,26 +324,45 @@ class MarkdownReporter:
             "|------|----------|-------|--------|------|------"
             "|--------------|---------------|------|-----------|"
         )
+        bucket_totals = summary.get("bucket_totals") or {}
+
+        def _row_md(band_label: str, category: str, data: Mapping[str, Any]) -> str:
+            return (
+                f"| {band_label} | {category} | {data.get('total_items', 0)}"
+                f" | {data.get('tested_items', 0)} | {data.get('pass', 0)}"
+                f" | {data.get('fail', 0)} | {data.get('to_be_tested', 0)}"
+                f" | {data.get('not_supported', 0)} | {data.get('skip', 0)}"
+                f" | {_format_percent(data.get('pass_rate'))} |"
+            )
+
+        def _emit_total(band_key: str) -> None:
+            total = bucket_totals.get(band_key)
+            if not total:
+                return
+            lines.append(_row_md(_BAND_LABELS.get(band_key, band_key), "**TOTAL**", total))
+
+        prev_key: str | None = None
         for row in band_category:
-            band = (
+            band_key = str(row.get("band_key", ""))
+            # 'WiFi.Other' is the categoriser's catch-all fallback; hide it when
+            # empty (no xlsx Summary counterpart). Any non-zero count still rolls
+            # into the per-band TOTAL below. Mirrors the HTML reporter.
+            if str(row.get("category", "")) == "WiFi.Other" and not row.get(
+                "total_items"
+            ):
+                continue
+            if prev_key is not None and band_key != prev_key:
+                _emit_total(prev_key)
+            band_label = (
                 row.get("band_label")
                 or row.get("band")
                 or row.get("band_key")
                 or ""
             )
-            category = row.get("category", "")
-            total = row.get("total_items", 0)
-            tested = row.get("tested_items", 0)
-            pass_ = row.get("pass", 0)
-            fail = row.get("fail", 0)
-            tbt = row.get("to_be_tested", 0)
-            ns = row.get("not_supported", 0)
-            skip = row.get("skip", 0)
-            pr = _format_percent(row.get("pass_rate"))
-            lines.append(
-                f"| {band} | {category} | {total} | {tested}"
-                f" | {pass_} | {fail} | {tbt} | {ns} | {skip} | {pr} |"
-            )
+            lines.append(_row_md(band_label, row.get("category", ""), row))
+            prev_key = band_key
+        if prev_key is not None:
+            _emit_total(prev_key)
         lines.append("")
 
     @staticmethod

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -300,6 +300,20 @@ _PRECOMPUTED_SUMMARY: dict[str, Any] = {
             "pass_rate": None,
             "progress": None,
         },
+        {
+            "band_key": "result_5g",
+            "band_label": "5G",
+            "category": "WiFi.Other",
+            "total_items": 0,
+            "tested_items": 0,
+            "pass": 0,
+            "fail": 0,
+            "to_be_tested": 0,
+            "not_supported": 0,
+            "skip": 0,
+            "pass_rate": None,
+            "progress": None,
+        },
     ],
     "bucket_totals": {
         "result_5g": {
@@ -361,3 +375,9 @@ def test_markdown_reporter_renders_hybrid_summary(tmp_path: Path) -> None:
     # Row for 5G/WiFi.AccessPoint with pass_rate 50.00%
     assert "50.00%" in text
     assert "WiFi.AccessPoint" in text
+    # Per-band TOTAL row from bucket_totals — must be aligned with the HTML reporter.
+    assert "**TOTAL**" in text
+    # The catch-all 'WiFi.Other' bucket is empty here → it has no xlsx counterpart
+    # and must be hidden (again, matching the HTML reporter), while still rolling
+    # into the per-band TOTAL.
+    assert "WiFi.Other" not in text


### PR DESCRIPTION
## Summary

Markdown 報表的 WiFi LLAPI Hybrid summary 表對齊 HTML 報表——修正先前只改 `html_reporter`、`reporter`(md) 未同步的落差：

- 空的 `WiFi.Other` catch-all 列（無 xlsx Summary 對應）改以該 band 的 **TOTAL 匯總列**取代（取自 `bucket_totals`，統計該 band 全 category 的總數，而非顯示 WiFi.Other 的 0）。
- 結果與 HTML 報表逐列一致（各 category 列 + 每 band 一列 TOTAL）。

## Validation

- 全 core suite 綠；`preflight-ci` policy PASS。
- 擴充 `test_markdown_reporter_renders_hybrid_summary`：加空 `WiFi.Other` fixture，斷言 md 輸出含 `**TOTAL**` 匯總列、且不再顯示空 `WiFi.Other`（TDD RED→GREEN）。
- 以實際 run 的 summary 渲染，md 表逐列等同 HTML。
