### PR TITLE
fix(runtime): run-backend serialwrap profile 支援 testbed console_profile 選型

### DIFF
--- a/changelog.d/station-console-profile.md
+++ b/changelog.d/station-console-profile.md
@@ -1,0 +1,2 @@
+### Changed
+- run-backend 裝置清單的 serialwrap session profile 不再硬編 `prpl-template`：優先讀 testbed 裝置的 `console_profile`（station-layer 選型鍵）、次之 `profile`，未指定時維持原預設。

--- a/src/testpilot/runtime/orchestrator_run_backend_compat.py
+++ b/src/testpilot/runtime/orchestrator_run_backend_compat.py
@@ -70,7 +70,11 @@ class OrchestratorRunBackendCompat:
                     {
                         "com": selector,
                         "alias": alias,
-                        "profile": "prpl-template",
+                        # testbed 可用 console_profile（station-layer）或 profile 指定
+                        # serialwrap session profile；未指定維持 prpl-template。
+                        "profile": cfg.get(
+                            "console_profile", cfg.get("profile", "prpl-template")
+                        ),
                         "serial_port": cfg.get("serial_port", ""),
                     }
                 )


### PR DESCRIPTION
station-layer P3 前置：STA 換板（BRCM BDK 用 brcm-template console）時 run-backend 的 serialwrap session profile 不再硬編 `prpl-template`——優先讀 testbed 裝置 `console_profile`（station-layer 選型鍵）、次之 `profile`、未指定維持原預設。

- 一行行為變更 + changelog fragment；core 測試 717 passed
- 對應 plugin 側：hamanpaul/wifi_llapi 的 station-layer 計畫（docs/superpowers/plans/2026-07-20-station-layer.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcNDJni8ceGNz2gwpKNsKg