### PR TITLE
chore(install): serialwrap managed-install pin 0.2.1 → 0.2.4

### DIFF
--- a/changelog.d/serialwrap-pin-0-2-4.md
+++ b/changelog.d/serialwrap-pin-0-2-4.md
@@ -1,0 +1,2 @@
+### Changed
+- managed-install serialwrap pin 由 `0.2.1` 提升至 `0.2.4`（`install-manifest.yaml`）。0.2.1→0.2.4 涵蓋 serialwrap `v0.2.2`~`v0.2.4`（174 commits）：daemon 暴露命令長度上限 `limits`（serialwrap#129）、arbiter recovery 佇列 flush（#128）、autoboot 倒數窗 recovery lease（#114/#140）、realhw 穩定性測試套件、Windows 原生 daemon 與 ssh 反向隧道 CLI。serialwrap 無 SDK API 契約，故維持顯式 `version:` pin，本次為刻意 bump（`main` HEAD 即 `v0.2.4`）。

--- a/install-manifest.yaml
+++ b/install-manifest.yaml
@@ -18,5 +18,5 @@ plugins:
     private: true
 serialwrap:
   repo: hamanpaul/serialwrap
-  version: "0.2.1"            # PINNED — no API contract; bump deliberately
+  version: "0.2.4"            # PINNED — no API contract; bump deliberately
   private: false


### PR DESCRIPTION
## 摘要

把 managed-install 的 serialwrap pin 由 `0.2.1` 提升至 `0.2.4`（`install-manifest.yaml`）。

serialwrap 無 SDK API 契約，於 manifest 以顯式 `version:` pin；core/plugins 靠 API 契約自動解版、不 pin。本次為**刻意 bump**（serialwrap `main` HEAD 即 `v0.2.4`）。

## 涵蓋範圍（0.2.1 → 0.2.4，174 commits / v0.2.2~v0.2.4）

- daemon 暴露可查詢的命令長度上限 `limits`（serialwrap PR 129）
- arbiter recovery 佇列 flush（serialwrap PR 128）
- autoboot 倒數窗 recovery lease（serialwrap PR 114/140，對應 BDK/BGW720 reboot recovery 痛點）
- realhw 實機穩定性測試套件（serialwrap PR 122）
- Windows 原生 daemon + ssh 反向隧道 CLI（serialwrap PR 84/143）

## 影響面

- 只動 `install-manifest.yaml` 的 pin；`src/testpilot/install/manifest.py` parser 與 `tests/test_install_manifest.py`（inline fixture，非讀真檔）不受影響。
- 線上 managed-install 路徑生效；離線 bundle 的 serialwrap 版本由 `wifi_llapi/scripts/make-bundle.sh` 的 `SERIALWRAP_REF` 另行控制（另一 PR 同步 bump）。

## 測試

- `.venv/bin/python -m pytest -q tests` 綠（唯一失敗 `test_offline_creates_wrapper` 為本機 Python cp312≠bundle cp311 環境不符，pre-existing 於 main、CI 跑 3.11 不受影響）。

無對應 issue。
