### PR TITLE
fix(runtime): console_profile truthy fallback + fragment front-matter（PR 25 review follow-up）

### DIFF
--- a/changelog.d/station-console-profile.md
+++ b/changelog.d/station-console-profile.md
@@ -1,2 +1,5 @@
-### Changed
-- run-backend 裝置清單的 serialwrap session profile 不再硬編 `prpl-template`：優先讀 testbed 裝置的 `console_profile`（station-layer 選型鍵）、次之 `profile`，未指定時維持原預設。
+---
+type: fix
+scope: runtime
+---
+run-backend 裝置清單的 serialwrap session profile 不再硬編 `prpl-template`：優先讀 testbed 裝置的 `console_profile`（station-layer 選型鍵）、次之 `profile`，空值/缺席一律回退預設（truthy fallback，避免空 profile 產生畸形 session_id）。

--- a/src/testpilot/runtime/orchestrator_run_backend_compat.py
+++ b/src/testpilot/runtime/orchestrator_run_backend_compat.py
@@ -72,8 +72,12 @@ class OrchestratorRunBackendCompat:
                         "alias": alias,
                         # testbed 可用 console_profile（station-layer）或 profile 指定
                         # serialwrap session profile；未指定維持 prpl-template。
-                        "profile": cfg.get(
-                            "console_profile", cfg.get("profile", "prpl-template")
+                        # truthy fallback：空字串/None 也回退，避免產生
+                        # "None:COM0" 之類的 session_id。
+                        "profile": (
+                            cfg.get("console_profile")
+                            or cfg.get("profile")
+                            or "prpl-template"
                         ),
                         "serial_port": cfg.get("serial_port", ""),
                     }


### PR DESCRIPTION
PR 25 合入後補其兩則 review findings：

- `console_profile`/`profile` 空字串或 null 時以 truthy fallback 回退 `prpl-template`，避免產生 `None:COM0` 類畸形 session_id
- `changelog.d/station-console-profile.md` 改為 front-matter 格式（type/scope，policy collate 需求）
- core 測試 717 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcNDJni8ceGNz2gwpKNsKg