### PR TITLE
feat(cli): #30 支援以路徑直接執行外部 plugin 專案

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,40 @@ This README is the canonical install reference. For online install (managed venv
 Use `testpilot list-plugins` to see installed plugins and `testpilot run <plugin>`
 to drive them.
 
+A plugin can be selected two ways:
+
+| Form | Resolution | Use when |
+| --- | --- | --- |
+| `testpilot <PLUGIN_NAME> [ARGS]...` | registry mode — `testpilot.plugins` entry points of the installed environment | the plugin is installed |
+| `testpilot <PLUGIN_PATH> [ARGS]...` | path mode — a plugin project directory on disk | running a checkout that is not (or not yet) installed |
+
+```bash
+testpilot <plugin> --case D001            # registry mode
+testpilot /path/to/my_plugin --case D001  # path mode, same plugin command
+testpilot ../my_plugin                    # relative paths work too
+```
+
+Both forms dispatch to the same plugin-owned command, so plugin-specific options
+behave identically. Path mode details:
+
+- `PLUGIN_PATH` is the **project root** — the directory containing
+  `pyproject.toml` with a `[project.entry-points."testpilot.plugins"]` table.
+  That table is the single source of truth for the plugin's name and import
+  target, so both modes agree on identity.
+- The project must declare exactly one plugin. More than one is refused rather
+  than guessed; install the project and select by name instead.
+- The project copy wins over an installed distribution of the same name, even
+  when that distribution is already imported. If the declared module still
+  resolves outside the requested project, the run is refused rather than
+  silently testing the wrong tree.
+- Path mode does not skip the SDK API-version gate — an incompatible plugin is
+  rejected exactly as in registry mode.
+- A registered plugin name always takes precedence over a same-named directory
+  in the working directory, so path mode can never shadow an installed plugin.
+- A token is read as a path when it contains a separator, starts with `.` or
+  `~`, or names an existing directory. Anything else is treated as a plugin
+  name or subcommand.
+
 ## Version
 
 The canonical project version is `VERSION`; release tags use `vX.Y.Z`.
@@ -192,6 +226,20 @@ Usage: testpilot [OPTIONS] COMMAND [ARGS]...
 
   TestPilot — plugin-based test automation for embedded devices.
 
+  A plugin can be selected two ways:
+    testpilot <PLUGIN_NAME> [ARGS]...  registry mode — an installed plugin,
+                                       resolved via testpilot.plugins entry
+                                       points
+    testpilot <PLUGIN_PATH> [ARGS]...  path mode — a plugin project directory
+                                       (the one holding pyproject.toml with a
+                                       testpilot.plugins entry point); runs
+                                       without installing it, e.g.
+                                       testpilot /path/to/plugin
+
+  Both forms dispatch to the same plugin-owned command, so plugin options
+  apply identically. PLUGIN_PATH may be absolute or relative; a registered
+  plugin name always takes precedence over a same-named directory.
+
 Options:
   --version         Show version and exit.
   -v, --verbose     Enable debug logging.
@@ -216,6 +264,20 @@ Commands:
 Usage: testpilot [OPTIONS] COMMAND [ARGS]...
 
   TestPilot — plugin-based test automation for embedded devices.
+
+  A plugin can be selected two ways:
+    testpilot <PLUGIN_NAME> [ARGS]...  registry mode — an installed plugin,
+                                       resolved via testpilot.plugins entry
+                                       points
+    testpilot <PLUGIN_PATH> [ARGS]...  path mode — a plugin project directory
+                                       (the one holding pyproject.toml with a
+                                       testpilot.plugins entry point); runs
+                                       without installing it, e.g.
+                                       testpilot /path/to/plugin
+
+  Both forms dispatch to the same plugin-owned command, so plugin options
+  apply identically. PLUGIN_PATH may be absolute or relative; a registered
+  plugin name always takes precedence over a same-named directory.
 
 Options:
   --version         Show version and exit.
@@ -448,6 +510,34 @@ testpilot list-plugins
 testpilot list-cases <plugin>
 testpilot run <plugin>
 ```
+
+選擇 plugin 有兩種形式：
+
+| 形式 | 解析方式 | 使用時機 |
+| --- | --- | --- |
+| `testpilot <PLUGIN_NAME> [ARGS]...` | registry mode——目前環境已安裝的 `testpilot.plugins` entry point | plugin 已安裝 |
+| `testpilot <PLUGIN_PATH> [ARGS]...` | path mode——磁碟上的 plugin 專案目錄 | 要跑尚未（或不打算）安裝的 checkout |
+
+```bash
+testpilot <plugin> --case D001            # registry mode
+testpilot /path/to/my_plugin --case D001  # path mode，同一個 plugin 指令
+testpilot ../my_plugin                    # 相對路徑同樣可用
+```
+
+兩種形式都 dispatch 到同一個 plugin 自有指令，因此 plugin 專屬選項行為完全一致。
+path mode 細節：
+
+- `PLUGIN_PATH` 指的是**專案根目錄**——含 `pyproject.toml` 且宣告
+  `[project.entry-points."testpilot.plugins"]` 的那一層。該表是 plugin 名稱與
+  import 目標的唯一真實來源，因此兩種模式對「這是哪個 plugin」的認定一致。
+- 專案必須剛好宣告一個 plugin。宣告多個時直接拒絕而不猜測，請改為安裝後以名稱選取。
+- 專案內那份優先於同名的已安裝套件，**即使該套件已經被 import 過**。若宣告的模組
+  最終仍解析到專案之外，會直接拒絕執行，而不是靜默測到錯的那棵樹。
+- path mode 不會繞過 SDK API 版本閘：不相容的 plugin 與 registry mode 一樣被拒絕。
+- 已註冊的 plugin 名稱永遠優先於工作目錄下的同名資料夾，因此 path mode 不可能遮蔽
+  已安裝的 plugin。
+- 判定為路徑的條件：含路徑分隔符、以 `.` 或 `~` 開頭、或該名稱確實是一個既有目錄。
+  其餘一律視為 plugin 名稱或子命令。
 
 ### Azure OpenAI（BYOK）
 

--- a/changelog.d/30-plugin-path-mode.md
+++ b/changelog.d/30-plugin-path-mode.md
@@ -52,10 +52,12 @@ plugin 未註冊同名 command 時才退回核心 run 路徑。
 - `testpilot/cli.py`：`main` 改用 `PluginPathGroup`，`resolve_command` 在第一個 token 不是
   已註冊命令、且看起來像路徑時走 path mode。判定條件保守：含路徑分隔符、以 `.`／`~` 開頭、
   或該名稱確實是既有目錄。實作維持 plugin 零具名（`tests/test_cli_plugin_registration.py` 守門）。
+  override 以 `ctx.call_on_close` 綁在 click context 生命週期上，指令結束（成功或失敗）即清除——
+  process-wide 的 override 若殘留，之後對同名的解析會拿到上一輪的過期實例。
 
 ## 測試與文件
 
-新增 `tests/test_cli_plugin_path_mode.py`（11 個測試），含「同 package 名、已安裝那份已進
+新增 `tests/test_cli_plugin_path_mode.py`（14 個測試），含「同 package 名、已安裝那份已進
 `sys.modules`」的碰撞情境——這正是不做 module 驅逐就會靜默跑錯樹的那一條。另有 registry mode
 未回歸、相對路徑、四種 fail-closed 錯誤與 help 內容的覆蓋。
 

--- a/changelog.d/30-plugin-path-mode.md
+++ b/changelog.d/30-plugin-path-mode.md
@@ -1,0 +1,63 @@
+---
+type: feat
+scope: cli
+issue: 30
+---
+`testpilot <PLUGIN_PATH>` 可直接執行磁碟上的 plugin 專案，不需先安裝進 registry（#30）。
+
+## 兩種 invocation 形式
+
+| 形式 | 解析方式 |
+|---|---|
+| `testpilot <PLUGIN_NAME> [ARGS]...` | registry mode——已安裝的 `testpilot.plugins` entry point（既有行為，未變） |
+| `testpilot <PLUGIN_PATH> [ARGS]...` | path mode——磁碟上的 plugin 專案根目錄（新增） |
+
+`PLUGIN_PATH` 指專案根目錄（含 `pyproject.toml` 那層）。專案自己的
+`[project.entry-points."testpilot.plugins"]` 表是 plugin 名稱與 import 目標的唯一真實來源，
+因此兩種模式對 plugin 身分的認定一致，只有解析路徑不同。
+
+## 完整 parity，而非另一條簡化路徑
+
+path mode 跑的是 plugin **自己** 透過 `register_cli` 註冊的 command，因此
+`testpilot /path/to/p --flag` 與 `testpilot p --flag` 行為完全一致，plugin 專屬選項照常可用。
+plugin 未註冊同名 command 時才退回核心 run 路徑。
+
+這需要一個 loader 層的名稱 override：plugin 自有 command 內部會以**名稱**重新解析自己
+（`get_orchestrator(ctx, name)` → `load_registered_plugin(name)`，且 `Orchestrator` 自建
+一個新的 `PluginLoader`）。沒有 override 的話，path mode 會在乾淨環境直接找不到 plugin，
+或在有安裝的環境**靜默跑到已安裝的那份**——後者比不支援還糟。`PluginLoader.register_override`
+讓所有 loader 實例對「這個名字是誰」取得一致答案。
+
+## 「跑到路徑那份」的保證
+
+僅把專案路徑前插 `sys.path` 並不夠：同名發行版若已被 import，其 top-level package 已在
+`sys.modules`，`import_module` 會直接回快取的那份。因此 path mode 會先驅逐不屬於本專案的
+同名 top-level module，再 import，並**驗證載入結果確實位於專案根目錄之下**；驗證不過就
+拒絕執行，而不是靜默測到錯的樹。
+
+## Fail-closed 行為
+
+- 路徑不存在 / 不是目錄 / 缺 `pyproject.toml` / 沒有 `testpilot.plugins` entry point：各自給出明確訊息。
+- 專案宣告多個 plugin：**拒絕而不猜測**，並列出候選名稱，建議改為安裝後以名稱選取。
+- entry point 值格式錯誤、屬性不存在、不是 `PluginBase` 子類：明確拒絕。
+- path mode **不繞過** SDK API 版本閘，與 registry mode 共用同一個 `_check_api_compat`。
+- 已註冊的 plugin 名稱永遠優先於同名資料夾，path mode 不可能遮蔽已安裝的 plugin。
+
+## 實作
+
+- 新增 `testpilot/core/plugin_project.py`：路徑解析、pyproject entry-point 讀取、
+  專案優先 import 與位置驗證、plugin 實例化。
+- `testpilot/core/plugin_loader.py`：新增 class 層級的名稱 override（`register_override` /
+  `clear_overrides`），`load()` 優先查詢。
+- `testpilot/cli.py`：`main` 改用 `PluginPathGroup`，`resolve_command` 在第一個 token 不是
+  已註冊命令、且看起來像路徑時走 path mode。判定條件保守：含路徑分隔符、以 `.`／`~` 開頭、
+  或該名稱確實是既有目錄。實作維持 plugin 零具名（`tests/test_cli_plugin_registration.py` 守門）。
+
+## 測試與文件
+
+新增 `tests/test_cli_plugin_path_mode.py`（11 個測試），含「同 package 名、已安裝那份已進
+`sys.modules`」的碰撞情境——這正是不做 module 驅逐就會靜默跑錯樹的那一條。另有 registry mode
+未回歸、相對路徑、四種 fail-closed 錯誤與 help 內容的覆蓋。
+
+README（en/zh 兩段）新增兩種形式的對照表與 path mode 細節；`docs/plugin-dev-guide.md` 補上
+「開發期免安裝跑法」；R-16 的 `testpilot-help` / `testpilot-update-help` marker 區塊已重生。

--- a/docs/plugin-dev-guide.md
+++ b/docs/plugin-dev-guide.md
@@ -92,6 +92,14 @@ implementation detail；若有新 core/schema symbol 要成為穩定契約，必
    `uv pip install -e .`
 5. 驗證：`testpilot list-plugins`，接著 `testpilot list-cases my_plugin`
 
+> **開發期免安裝跑法（path mode，#30）**：步驟 2 的 entry point 一寫好，就可以用
+> `testpilot /path/to/my_plugin`（專案根目錄，即含 `pyproject.toml` 那層）直接執行，
+> 不必先做步驟 4 的安裝。path mode 讀的是專案自己的 entry-point 宣告，跑的是專案內
+> 那份 source——即使環境裡另有同名的已安裝套件也一樣。`list-plugins` / `list-cases`
+> 仍只列出**已安裝**的 plugin，因此步驟 4/5 的驗證流程不變。
+
+
+
 ### 選配 hook（plugin 透過 PluginBase 接入 core）
 
 除上述必要方法外，plugin 可覆寫以下選配 hook，把 plugin 專屬行為透過

--- a/src/testpilot/cli.py
+++ b/src/testpilot/cli.py
@@ -1158,7 +1158,84 @@ def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> 
     ctx.exit()
 
 
-@click.group(invoke_without_command=True)
+def _looks_like_plugin_path(token: str) -> bool:
+    """Whether *token* should be read as a plugin-project path, not a command.
+
+    Deliberately conservative: a registered command name always wins (checked
+    by the caller), and a bare word is only treated as a path when a directory
+    of that name actually exists in the working directory.
+    """
+    if not token or token.startswith("-"):
+        return False
+    if token.startswith(("~", ".")) or "/" in token or os.sep in token:
+        return True
+    return Path(token).is_dir()
+
+
+def _plugin_path_command(path: str) -> tuple[str, click.Command]:
+    """Load the plugin project at *path* and return its CLI command.
+
+    Path mode aims for full parity with registry mode: the plugin's own
+    ``register_cli`` command (with its own options) is what runs, so
+    ``testpilot <path> --flag`` behaves exactly like ``testpilot <name> --flag``.
+    The loaded instance is registered as a loader override first, because the
+    plugin's command re-resolves itself by name and must reach *this* copy.
+    """
+    from testpilot.core.plugin_loader import PluginLoader
+    from testpilot.core.plugin_project import PluginProjectError, load_plugin_project
+
+    try:
+        name, plugin = load_plugin_project(path)
+    except PluginProjectError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    PluginLoader.register_override(name, plugin)
+
+    staging = click.Group()
+    try:
+        plugin.register_cli(CliRegistrar(staging))
+    except Exception as exc:
+        raise click.UsageError(
+            f"plugin {name!r} failed to register its CLI: {exc}"
+        ) from exc
+
+    command = staging.commands.get(name)
+    if command is not None:
+        return name, command
+
+    # The plugin exposes no command of its own; fall back to the generic run
+    # path so path mode still executes its cases.
+    @click.command(name)
+    @click.option("--case", "case_ids", multiple=True, help="Specific case IDs to run.")
+    @click.option(
+        "--dut-fw-ver",
+        default="DUT-FW-VER",
+        show_default=True,
+        help="DUT firmware version used in report filename.",
+    )
+    @click.pass_context
+    def _fallback_run(
+        ctx: click.Context, case_ids: tuple[str, ...], dut_fw_ver: str
+    ) -> None:
+        """Run this plugin's cases (plugin declares no CLI of its own)."""
+        run_plugin_cases(ctx, name, case_ids, dut_fw_ver)
+
+    return name, _fallback_run
+
+
+class PluginPathGroup(click.Group):
+    """Root group that also accepts a plugin-project path as the command."""
+
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        if args and args[0] not in self.commands and _looks_like_plugin_path(args[0]):
+            name, command = _plugin_path_command(args[0])
+            return name, command, args[1:]
+        return super().resolve_command(ctx, args)
+
+
+@click.group(invoke_without_command=True, cls=PluginPathGroup)
 @click.option(
     "--version",
     is_eager=True,
@@ -1206,7 +1283,23 @@ def main(
     update_ref: str | None,
     verify_install: bool,
 ) -> None:
-    """TestPilot — plugin-based test automation for embedded devices."""
+    """TestPilot — plugin-based test automation for embedded devices.
+
+    \b
+    A plugin can be selected two ways:
+      testpilot <PLUGIN_NAME> [ARGS]...  registry mode — an installed plugin,
+                                         resolved via testpilot.plugins entry
+                                         points
+      testpilot <PLUGIN_PATH> [ARGS]...  path mode — a plugin project directory
+                                         (the one holding pyproject.toml with a
+                                         testpilot.plugins entry point); runs
+                                         without installing it, e.g.
+                                         testpilot /path/to/plugin
+
+    Both forms dispatch to the same plugin-owned command, so plugin options
+    apply identically. PLUGIN_PATH may be absolute or relative; a registered
+    plugin name always takes precedence over a same-named directory.
+    """
     # Pre-dispatch: --update and --verify-install run before normal routing.
     if update_ref is not None:
         if update_ref not in (None, "main"):

--- a/src/testpilot/cli.py
+++ b/src/testpilot/cli.py
@@ -1172,7 +1172,7 @@ def _looks_like_plugin_path(token: str) -> bool:
     return Path(token).is_dir()
 
 
-def _plugin_path_command(path: str) -> tuple[str, click.Command]:
+def _plugin_path_command(ctx: click.Context, path: str) -> tuple[str, click.Command]:
     """Load the plugin project at *path* and return its CLI command.
 
     Path mode aims for full parity with registry mode: the plugin's own
@@ -1180,6 +1180,11 @@ def _plugin_path_command(path: str) -> tuple[str, click.Command]:
     ``testpilot <path> --flag`` behaves exactly like ``testpilot <name> --flag``.
     The loaded instance is registered as a loader override first, because the
     plugin's command re-resolves itself by name and must reach *this* copy.
+
+    The override is process-wide, so it is scoped to *ctx* and cleared when the
+    context closes — success or failure. Leaving it registered would let a
+    later resolution of the same name return a stale instance from a previous
+    invocation, which in-process hosts (and the test suite) hit immediately.
     """
     from testpilot.core.plugin_loader import PluginLoader
     from testpilot.core.plugin_project import PluginProjectError, load_plugin_project
@@ -1190,6 +1195,7 @@ def _plugin_path_command(path: str) -> tuple[str, click.Command]:
         raise click.UsageError(str(exc)) from exc
 
     PluginLoader.register_override(name, plugin)
+    ctx.call_on_close(PluginLoader.clear_overrides)
 
     staging = click.Group()
     try:
@@ -1230,7 +1236,7 @@ class PluginPathGroup(click.Group):
         self, ctx: click.Context, args: list[str]
     ) -> tuple[str | None, click.Command | None, list[str]]:
         if args and args[0] not in self.commands and _looks_like_plugin_path(args[0]):
-            name, command = _plugin_path_command(args[0])
+            name, command = _plugin_path_command(ctx, args[0])
             return name, command, args[1:]
         return super().resolve_command(ctx, args)
 

--- a/src/testpilot/core/plugin_loader.py
+++ b/src/testpilot/core/plugin_loader.py
@@ -33,7 +33,12 @@ def _parse_api_version(plugin_name: str, version: object, *, role: str) -> tuple
 
 
 def _check_api_compat(name: str, declared: object, api: object) -> None:
-    """Validate plugin-declared SDK API compatibility."""
+    """Validate plugin-declared SDK API compatibility.
+
+    Package-private, but also used by path-mode loading
+    (``testpilot.core.plugin_project``) so resolving a plugin by path cannot
+    sidestep the SDK API version gate.
+    """
     if declared is None:
         raise IncompatiblePluginError(f"plugin {name!r} must declare api_version")
 
@@ -66,6 +71,27 @@ class PluginLoader:
     """動態發現並載入 ``testpilot.plugins`` entry point 宣告的 plugin。"""
 
     ENTRY_POINT_GROUP = "testpilot.plugins"
+
+    # Process-wide name -> instance overrides, populated by path mode (#30).
+    #
+    # Plugin-owned CLI commands re-resolve themselves by name through a *fresh*
+    # loader (``get_orchestrator`` -> ``load_registered_plugin``, and
+    # ``Orchestrator`` builds its own ``PluginLoader``). Without a shared
+    # override, `testpilot <path>` would load the on-disk plugin only to have
+    # the plugin's own command silently fall back to the installed copy — or
+    # fail outright in a clean environment where nothing is installed. Keeping
+    # the mapping on the class makes every loader instance agree on identity.
+    _overrides: dict[str, PluginBase] = {}
+
+    @classmethod
+    def register_override(cls, name: str, plugin: PluginBase) -> None:
+        """Bind *name* to an already-loaded *plugin* for every loader."""
+        PluginLoader._overrides[name] = plugin
+
+    @classmethod
+    def clear_overrides(cls) -> None:
+        """Drop all name overrides (test isolation / repeated invocations)."""
+        PluginLoader._overrides.clear()
 
     @classmethod
     def for_entry_points(cls) -> "PluginLoader":
@@ -120,6 +146,9 @@ class PluginLoader:
 
     def load(self, name: str) -> PluginBase:
         """載入指定 plugin 並回傳其實例。"""
+        override = PluginLoader._overrides.get(name)
+        if override is not None:
+            return override
         if name in self._plugins:
             return self._plugins[name]
 

--- a/src/testpilot/core/plugin_loader.py
+++ b/src/testpilot/core/plugin_loader.py
@@ -81,6 +81,11 @@ class PluginLoader:
     # the plugin's own command silently fall back to the installed copy — or
     # fail outright in a clean environment where nothing is installed. Keeping
     # the mapping on the class makes every loader instance agree on identity.
+    #
+    # These deliberately address ``PluginLoader._overrides`` rather than
+    # ``cls._overrides``: a single shared registry IS the invariant. A subclass
+    # that shadowed ``_overrides`` would silently split it in two and reinstate
+    # exactly the divergence this exists to prevent.
     _overrides: dict[str, PluginBase] = {}
 
     @classmethod

--- a/src/testpilot/core/plugin_project.py
+++ b/src/testpilot/core/plugin_project.py
@@ -1,0 +1,204 @@
+"""Load a plugin straight from an on-disk project directory (path mode, #30).
+
+Registry mode resolves a plugin through the installed ``testpilot.plugins``
+entry points. Path mode instead points at a plugin **project root** — the
+directory holding ``pyproject.toml`` — and loads the plugin it declares,
+without requiring that project to be installed into the current environment.
+
+The project's own ``[project.entry-points."testpilot.plugins"]`` table is the
+single source of truth for the plugin's name and import target, so path mode
+and registry mode agree on identity; only the resolution route differs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+import sys
+import tomllib
+from typing import Any
+
+from testpilot.core.plugin_base import PluginBase
+
+log = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "testpilot.plugins"
+PYPROJECT_NAME = "pyproject.toml"
+
+
+class PluginProjectError(Exception):
+    """Raised when a path does not resolve to a loadable plugin project."""
+
+
+def resolve_project_root(path: str | Path) -> Path:
+    """Normalize *path* to an existing plugin-project directory."""
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    try:
+        candidate = candidate.resolve()
+    except OSError as exc:  # pragma: no cover - defensive
+        raise PluginProjectError(f"plugin project path not found: {path} ({exc})") from exc
+
+    if not candidate.exists():
+        raise PluginProjectError(f"plugin project path not found: {path}")
+    if not candidate.is_dir():
+        raise PluginProjectError(
+            f"plugin project path is not a directory: {candidate}"
+        )
+    return candidate
+
+
+def read_project_entry_points(project_root: Path) -> dict[str, str]:
+    """Return the project's declared ``testpilot.plugins`` entry points."""
+    pyproject = project_root / PYPROJECT_NAME
+    if not pyproject.is_file():
+        raise PluginProjectError(
+            f"{project_root} is not a plugin project: no {PYPROJECT_NAME}"
+        )
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        raise PluginProjectError(f"cannot parse {pyproject}: {exc}") from exc
+
+    declared = (
+        data.get("project", {}).get("entry-points", {}).get(ENTRY_POINT_GROUP, {})
+    )
+    entry_points = {
+        name.strip(): value.strip()
+        for name, value in (declared.items() if isinstance(declared, dict) else [])
+        if isinstance(name, str)
+        and name.strip()
+        and not name.startswith("_")
+        and isinstance(value, str)
+        and value.strip()
+    }
+    if not entry_points:
+        raise PluginProjectError(
+            f"{project_root} declares no {ENTRY_POINT_GROUP} entry point in "
+            f"{PYPROJECT_NAME}; it is not a TestPilot plugin project"
+        )
+    return entry_points
+
+
+def _import_from_project(module_name: str, project_root: Path) -> Any:
+    """Import *module_name* so that the copy under *project_root* wins.
+
+    Prepending the project to ``sys.path`` is not sufficient on its own: if the
+    same distribution is also pip-installed, its top-level package is already in
+    ``sys.modules`` and ``import_module`` would hand back that cached copy —
+    path mode would silently exercise the installed tree instead of the one the
+    operator pointed at. So the stale top-level package (and its submodules) is
+    evicted first, and the result is verified to actually live under the
+    project root before it is used.
+    """
+    root_text = str(project_root)
+    if sys.path and sys.path[0] == root_text:
+        pass
+    else:
+        while root_text in sys.path:
+            sys.path.remove(root_text)
+        sys.path.insert(0, root_text)
+
+    top_level = module_name.split(".")[0]
+    cached = sys.modules.get(top_level)
+    if cached is not None and not _module_is_under(cached, project_root):
+        for name in [
+            name
+            for name in sys.modules
+            if name == top_level or name.startswith(f"{top_level}.")
+        ]:
+            del sys.modules[name]
+    importlib.invalidate_caches()
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise PluginProjectError(
+            f"cannot import {module_name!r} from {project_root}: {exc}"
+        ) from exc
+
+    if not _module_is_under(module, project_root):
+        located = getattr(module, "__file__", None) or "<unknown location>"
+        raise PluginProjectError(
+            f"refusing to run: {module_name!r} resolved to {located}, which is "
+            f"outside the requested project {project_root}"
+        )
+    return module
+
+
+def _module_is_under(module: Any, project_root: Path) -> bool:
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        # Namespace packages have no __file__; fall back to their search paths.
+        search_paths = list(getattr(module, "__path__", []) or [])
+        return any(
+            Path(entry).resolve().is_relative_to(project_root) for entry in search_paths
+        )
+    try:
+        return Path(module_file).resolve().is_relative_to(project_root)
+    except OSError:  # pragma: no cover - defensive
+        return False
+
+
+def load_plugin_project(path: str | Path) -> tuple[str, PluginBase]:
+    """Load the single plugin declared by the project at *path*.
+
+    Returns ``(plugin_name, instance)``. Raises :class:`PluginProjectError`
+    when the path is not a plugin project, when the project declares more than
+    one plugin (ambiguous — refuse rather than guess), or when the declared
+    entry point does not resolve to a usable :class:`PluginBase` subclass.
+    """
+    project_root = resolve_project_root(path)
+    entry_points = read_project_entry_points(project_root)
+    if len(entry_points) > 1:
+        names = ", ".join(sorted(entry_points))
+        raise PluginProjectError(
+            f"{project_root} declares multiple {ENTRY_POINT_GROUP} entry points "
+            f"({names}); path mode needs exactly one — install the project and "
+            f"select by name instead"
+        )
+
+    name, target = next(iter(entry_points.items()))
+    module_name, separator, attribute = target.partition(":")
+    module_name = module_name.strip()
+    attribute = attribute.strip()
+    if not separator or not module_name or not attribute:
+        raise PluginProjectError(
+            f"invalid {ENTRY_POINT_GROUP} entry point for {name!r}: {target!r} "
+            f"(expected 'module:Attribute')"
+        )
+
+    module = _import_from_project(module_name, project_root)
+    plugin_cls = getattr(module, attribute, None)
+    if plugin_cls is None:
+        raise PluginProjectError(
+            f"{module_name!r} does not define {attribute!r} (declared by {name!r})"
+        )
+    if not isinstance(plugin_cls, type) or not issubclass(plugin_cls, PluginBase):
+        raise PluginProjectError(
+            f"plugin class must inherit PluginBase: {plugin_cls!r}"
+        )
+
+    # Same SDK-compat contract as registry mode — path mode must not become a
+    # way to sidestep the API version gate.
+    from testpilot.api import API_VERSION
+    from testpilot.core.plugin_loader import _check_api_compat
+
+    _check_api_compat(name, getattr(plugin_cls, "api_version", None), API_VERSION)
+
+    try:
+        instance = plugin_cls()
+    except Exception as exc:
+        raise PluginProjectError(
+            f"cannot instantiate plugin {name!r} from {project_root}: {exc}"
+        ) from exc
+
+    log.info(
+        "loaded plugin from project path: %s v%s (%s)",
+        instance.name,
+        instance.version,
+        project_root,
+    )
+    return name, instance

--- a/src/testpilot/core/plugin_project.py
+++ b/src/testpilot/core/plugin_project.py
@@ -65,15 +65,18 @@ def read_project_entry_points(project_root: Path) -> dict[str, str]:
     declared = (
         data.get("project", {}).get("entry-points", {}).get(ENTRY_POINT_GROUP, {})
     )
-    entry_points = {
-        name.strip(): value.strip()
-        for name, value in (declared.items() if isinstance(declared, dict) else [])
-        if isinstance(name, str)
-        and name.strip()
-        and not name.startswith("_")
-        and isinstance(value, str)
-        and value.strip()
-    }
+    entry_points: dict[str, str] = {}
+    for raw_name, raw_value in declared.items() if isinstance(declared, dict) else []:
+        if not isinstance(raw_name, str) or not isinstance(raw_value, str):
+            continue
+        # Normalize once, then filter on the normalized form: filtering the raw
+        # key while storing the stripped one let a padded key like " _hidden"
+        # slip past the reserved-name check and land as "_hidden".
+        name = raw_name.strip()
+        value = raw_value.strip()
+        if not name or not value or name.startswith("_"):
+            continue
+        entry_points[name] = value
     if not entry_points:
         raise PluginProjectError(
             f"{project_root} declares no {ENTRY_POINT_GROUP} entry point in "

--- a/tests/test_cli_plugin_path_mode.py
+++ b/tests/test_cli_plugin_path_mode.py
@@ -109,9 +109,14 @@ def _write_plugin_project(
 @pytest.fixture(autouse=True)
 def _restore_import_state():
     """Path mode mutates sys.path / sys.modules; keep tests isolated."""
+    from testpilot.core.plugin_loader import PluginLoader
+
     original_path = list(sys.path)
     original_modules = set(sys.modules)
     yield
+    # Path mode also mutates the class-level name overrides; a leaked override
+    # would let one test's plugin answer another test's name lookup.
+    PluginLoader.clear_overrides()
     sys.path[:] = original_path
     for name in set(sys.modules) - original_modules:
         del sys.modules[name]
@@ -315,3 +320,64 @@ def test_cli_py_still_names_no_plugin() -> None:
     src = (REPO / "src/testpilot/cli.py").read_text(encoding="utf-8")
     for name in ("wifi_llapi", "wifi-llapi", "brcm"):
         assert name not in src
+
+
+def test_override_does_not_outlive_the_invocation(tmp_path: Path) -> None:
+    """#30 review: the name override is process-wide and must not leak.
+
+    It exists only so the plugin's own command can resolve itself by name
+    during this invocation. Leaving it registered would make a later
+    resolution of the same name silently return a stale instance from a
+    previous run — in-process CLI invocations (tests, long-running hosts) hit
+    this immediately.
+    """
+    from testpilot.core.plugin_loader import PluginLoader
+
+    project = _write_plugin_project(
+        tmp_path / "proj", package="pathmode_leak", plugin_name="leaky", marker="LEAK"
+    )
+
+    result = CliRunner().invoke(_cli(), [str(project)])
+    assert result.exit_code == 0, result.output
+
+    assert PluginLoader._overrides == {}
+
+
+def test_override_is_cleared_even_when_the_plugin_command_fails(tmp_path: Path) -> None:
+    """A failed run must not leave the override behind either."""
+    from testpilot.core.plugin_loader import PluginLoader
+
+    project = _write_plugin_project(
+        tmp_path / "proj", package="pathmode_boom", plugin_name="boom", marker="BOOM"
+    )
+
+    result = CliRunner().invoke(_cli(), [str(project), "--no-such-option"])
+    assert result.exit_code != 0
+
+    assert PluginLoader._overrides == {}
+
+
+def test_entry_point_name_filter_uses_the_stored_key(tmp_path: Path) -> None:
+    """#30 review: the reserved-name filter must match the key actually stored.
+
+    The underscore check ran against the raw TOML key while the stripped form
+    was stored, so a padded key like `" _hidden"` slipped past the filter and
+    landed as `"_hidden"`.
+    """
+    from testpilot.core.plugin_project import PluginProjectError, read_project_entry_points
+
+    project = tmp_path / "padded"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '''[project]
+name = "padded"
+version = "0.0.1"
+
+[project.entry-points."testpilot.plugins"]
+" _hidden" = "padded.plugin:Plugin"
+''',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PluginProjectError, match="testpilot.plugins"):
+        read_project_entry_points(project)

--- a/tests/test_cli_plugin_path_mode.py
+++ b/tests/test_cli_plugin_path_mode.py
@@ -1,0 +1,317 @@
+"""#30: `testpilot /path/to/plugin-project` — path-mode plugin invocation.
+
+Registry mode (`testpilot <name>`) resolves a plugin through the installed
+``testpilot.plugins`` entry points. Path mode loads a plugin project directly
+from disk so it can be exercised without being installed into the current
+environment.
+
+The load-bearing property is that path mode must run the plugin **at that
+path** — not a same-named plugin that happens to be installed. Plugin-owned
+CLI commands re-resolve themselves by name (``get_orchestrator(ctx, name)``),
+so name resolution has to be redirected for the duration of the invocation or
+path mode would silently execute the installed copy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import textwrap
+
+import click
+from click.testing import CliRunner
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _write_plugin_project(
+    root: Path,
+    *,
+    package: str,
+    plugin_name: str,
+    marker: str,
+    entry_points: dict[str, str] | None = None,
+) -> Path:
+    """Materialize a minimal, importable plugin project on disk.
+
+    The plugin registers a CLI command named after itself (mirroring how real
+    plugins expose their run entry) and echoes *marker* so a test can prove
+    which copy executed.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    declared = entry_points or {plugin_name: f"{package}.plugin:Plugin"}
+    ep_lines = "\n".join(f'{name} = "{value}"' for name, value in declared.items())
+    (root / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+            [project]
+            name = "{package}"
+            version = "0.0.1"
+
+            [project.entry-points."testpilot.plugins"]
+            {ep_lines}
+            """
+        ),
+        encoding="utf-8",
+    )
+    pkg = root / package
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "plugin.py").write_text(
+        textwrap.dedent(
+            f'''\
+            from typing import Any
+
+            import click
+
+            from testpilot.core.plugin_base import PluginBase
+
+
+            class Plugin(PluginBase):
+                api_version = "1.2"
+
+                @property
+                def name(self) -> str:
+                    return "{plugin_name}"
+
+                @property
+                def version(self) -> str:
+                    return "9.9.9"
+
+                def discover_cases(self) -> list[dict[str, Any]]:
+                    return []
+
+                def execute_step(self, case, step, topology) -> dict[str, Any]:
+                    return {{"success": True, "output": "", "captured": {{}}, "timing": 0.0}}
+
+                def evaluate(self, case, results) -> bool:
+                    return True
+
+                def register_cli(self, registrar: Any) -> None:
+                    @click.command("{plugin_name}")
+                    @click.option("--case", "case_ids", multiple=True)
+                    @click.option("--plugin-only-flag", is_flag=True, default=False)
+                    def _run(case_ids, plugin_only_flag):
+                        click.echo("marker={marker}")
+                        click.echo(f"cases={{','.join(case_ids)}}")
+                        click.echo(f"flag={{plugin_only_flag}}")
+
+                    registrar.add_command(_run)
+            '''
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _restore_import_state():
+    """Path mode mutates sys.path / sys.modules; keep tests isolated."""
+    original_path = list(sys.path)
+    original_modules = set(sys.modules)
+    yield
+    sys.path[:] = original_path
+    for name in set(sys.modules) - original_modules:
+        del sys.modules[name]
+
+
+def _cli():
+    from testpilot.cli import main
+
+    return main
+
+
+def test_path_mode_runs_plugin_from_project_path(tmp_path: Path) -> None:
+    """A plugin project on disk runs without being installed."""
+    project = _write_plugin_project(
+        tmp_path / "proj", package="pathmode_a", plugin_name="pathmode_a", marker="A"
+    )
+
+    result = CliRunner().invoke(_cli(), [str(project)])
+
+    assert result.exit_code == 0, result.output
+    assert "marker=A" in result.output
+
+
+def test_path_mode_forwards_plugin_owned_options(tmp_path: Path) -> None:
+    """Parity with registry mode: the plugin's own options still apply."""
+    project = _write_plugin_project(
+        tmp_path / "proj", package="pathmode_b", plugin_name="pathmode_b", marker="B"
+    )
+
+    result = CliRunner().invoke(
+        _cli(), [str(project), "--case", "D001", "--plugin-only-flag"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "cases=D001" in result.output
+    assert "flag=True" in result.output
+
+
+def test_path_mode_beats_installed_plugin_of_the_same_name(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The whole point of path mode: run THAT copy, not the installed one.
+
+    Plugin-owned CLI commands re-resolve themselves by name, so an unguarded
+    implementation would load the entry-point copy and silently test the wrong
+    tree.
+
+    This mirrors the real collision: the installed distribution and the on-disk
+    checkout share the **same package name**, and the installed one is already
+    in ``sys.modules`` by the time path mode runs. Prepending the project to
+    ``sys.path`` is therefore not enough on its own — ``import_module`` would
+    hand back the cached installed module.
+    """
+    project = _write_plugin_project(
+        tmp_path / "proj", package="collidepkg", plugin_name="collide", marker="ONDISK"
+    )
+    installed = _write_plugin_project(
+        tmp_path / "installed",
+        package="collidepkg",
+        plugin_name="collide",
+        marker="INSTALLED",
+    )
+    sys.path.insert(0, str(installed))
+
+    import testpilot.core.plugin_loader as plugin_loader
+
+    # Import the installed copy first so it occupies sys.modules, exactly as it
+    # would in an environment where the plugin is pip-installed.
+    import collidepkg.plugin as installed_module
+
+    assert Path(installed_module.__file__).is_relative_to(installed)
+
+    class _FakeEntryPoint:
+        name = "collide"
+
+        def load(self):
+            return installed_module.Plugin
+
+    monkeypatch.setattr(
+        plugin_loader.metadata,
+        "entry_points",
+        lambda group=None: [_FakeEntryPoint()],
+    )
+
+    result = CliRunner().invoke(_cli(), [str(project)])
+
+    assert result.exit_code == 0, result.output
+    assert "marker=ONDISK" in result.output
+    assert "marker=INSTALLED" not in result.output
+
+
+def test_registry_mode_is_unchanged(tmp_path: Path, monkeypatch) -> None:
+    """A bare plugin name still resolves through the entry-point registry."""
+    installed = _write_plugin_project(
+        tmp_path / "installed",
+        package="pathmode_reg",
+        plugin_name="regmode",
+        marker="REGISTRY",
+    )
+    sys.path.insert(0, str(installed))
+
+    from testpilot.cli import _register_plugins
+    import testpilot.core.plugin_loader as plugin_loader
+
+    class _FakeEntryPoint:
+        name = "regmode"
+
+        def load(self):
+            from pathmode_reg.plugin import Plugin
+
+            return Plugin
+
+    monkeypatch.setattr(
+        plugin_loader.metadata,
+        "entry_points",
+        lambda group=None: [_FakeEntryPoint()],
+    )
+
+    group = _cli()
+    _register_plugins(group)
+    try:
+        result = CliRunner().invoke(group, ["regmode"])
+        assert result.exit_code == 0, result.output
+        assert "marker=REGISTRY" in result.output
+    finally:
+        group.commands.pop("regmode", None)
+
+
+def test_path_mode_rejects_missing_path(tmp_path: Path) -> None:
+    result = CliRunner().invoke(_cli(), [str(tmp_path / "nope")])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_path_mode_rejects_project_without_entry_point(tmp_path: Path) -> None:
+    """A directory that is not a plugin project must say so, not crash."""
+    project = tmp_path / "plain"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "plain"\nversion = "0.0.1"\n', encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(_cli(), [str(project)])
+
+    assert result.exit_code != 0
+    assert "testpilot.plugins" in result.output
+
+
+def test_path_mode_rejects_directory_without_pyproject(tmp_path: Path) -> None:
+    project = tmp_path / "bare"
+    project.mkdir()
+
+    result = CliRunner().invoke(_cli(), [str(project)])
+
+    assert result.exit_code != 0
+    assert "pyproject.toml" in result.output
+
+
+def test_path_mode_fails_closed_on_ambiguous_project(tmp_path: Path) -> None:
+    """Two declared plugins in one project: refuse rather than guess."""
+    project = _write_plugin_project(
+        tmp_path / "proj",
+        package="pathmode_multi",
+        plugin_name="first",
+        marker="MULTI",
+        entry_points={
+            "first": "pathmode_multi.plugin:Plugin",
+            "second": "pathmode_multi.plugin:Plugin",
+        },
+    )
+
+    result = CliRunner().invoke(_cli(), [str(project)])
+
+    assert result.exit_code != 0
+    assert "first" in result.output and "second" in result.output
+
+
+def test_relative_path_is_accepted(tmp_path: Path) -> None:
+    project = _write_plugin_project(
+        tmp_path / "proj", package="pathmode_rel", plugin_name="pathmode_rel", marker="REL"
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(_cli(), [f"../proj"])
+
+    assert result.exit_code == 0, result.output
+    assert "marker=REL" in result.output
+
+
+def test_help_documents_both_invocation_forms() -> None:
+    result = CliRunner().invoke(_cli(), ["--help"])
+
+    assert result.exit_code == 0
+    assert "PLUGIN_PATH" in result.output
+
+
+def test_cli_py_still_names_no_plugin() -> None:
+    """The path-mode implementation must stay plugin-agnostic (core guard)."""
+    src = (REPO / "src/testpilot/cli.py").read_text(encoding="utf-8")
+    for name in ("wifi_llapi", "wifi-llapi", "brcm"):
+        assert name not in src


### PR DESCRIPTION
## 需求

新增 path mode：`testpilot <PLUGIN_PATH> [ARGS]...` 直接載入磁碟上的 plugin 專案並執行，不需先安裝進 registry。registry mode（`testpilot <PLUGIN_NAME>`）行為完全未變。

`PLUGIN_PATH` 指**專案根目錄**（含 `pyproject.toml` 那層）。專案自己的 `[project.entry-points."testpilot.plugins"]` 是 plugin 名稱與 import 目標的唯一真實來源，因此兩種模式對「這是哪個 plugin」的認定一致，只有解析路徑不同。

## 為什麼做成完整 parity，而不是另一條簡化路徑

`testpilot wifi_llapi` 這種形式**不是** `run` 的別名——那是 plugin 透過 `register_cli` 自己註冊的 click command，帶有自有選項。所以 path mode 也 dispatch 到同一個 plugin 自有 command，`testpilot /path/to/p --flag` 與 `testpilot p --flag` 行為一致。plugin 未註冊同名 command 時才退回核心 run 路徑。

## 實作中發現並解掉的兩個陷阱

這兩點是本 PR 的重點，都會造成「靜默跑到錯的程式碼」——比功能不支援更糟。

### 1. plugin 自有 command 會用**名稱**把自己解析回 registry

wifi_llapi 的 command 內部呼叫 `get_orchestrator(ctx, "wifi_llapi")` → `load_registered_plugin(...)`，而 `Orchestrator` 又自建一個新的 `PluginLoader`。若只是「從路徑載入 plugin 然後叫它的 command」，command 內部會繞回 entry-point 查詢：

- 乾淨環境（正是 issue 驗收條件的情境）→ 直接找不到 plugin
- 有安裝同名 plugin 的環境 → **靜默執行已安裝的那份**

解法：`PluginLoader.register_override(name, instance)`，class 層級的名稱綁定，讓每個 loader 實例對「這個名字是誰」取得一致答案。

### 2. `sys.path` 前插不足以贏過已 import 的同名套件

真實碰撞是 installed 與 on-disk **同一個 package 名**。若該套件已被 import，其 top-level package 已在 `sys.modules`，`import_module` 會直接回快取那份——`sys.path` 怎麼排都沒用。

解法：先驅逐不屬於本專案的同名 top-level module（含子模組）再 import，並**驗證載入結果確實位於專案根目錄之下**；驗證不過就拒絕執行。這條由 `test_path_mode_beats_installed_plugin_of_the_same_name` 守門，測試刻意先 import 已安裝那份以重現 `sys.modules` 汙染。

## Fail-closed 行為

| 情況 | 行為 |
|---|---|
| 路徑不存在 / 不是目錄 | 明確訊息 |
| 缺 `pyproject.toml` | 訊息點名 `pyproject.toml` |
| 無 `testpilot.plugins` entry point | 訊息點名該 group |
| 宣告**多個** plugin | **拒絕而不猜測**，列出候選，建議安裝後以名稱選取 |
| entry point 值格式錯誤 / 屬性不存在 / 非 `PluginBase` 子類 | 明確拒絕 |
| SDK API 版本不相容 | 與 registry mode 共用同一個 `_check_api_compat`，**不繞過** |
| 工作目錄下有與已註冊 plugin 同名的資料夾 | 已註冊名稱優先，path mode 不可能遮蔽已安裝 plugin |

路徑判定刻意保守：含路徑分隔符、以 `.` 或 `~` 開頭、或該名稱確實是既有目錄，才視為路徑；其餘一律當 plugin 名稱或子命令。

## 實作

- 新增 `src/testpilot/core/plugin_project.py`：路徑解析、pyproject entry-point 讀取、專案優先 import 與位置驗證、plugin 實例化。
- `src/testpilot/core/plugin_loader.py`：新增 class 層級名稱 override（`register_override` / `clear_overrides`），`load()` 優先查詢。`_check_api_compat` 的 docstring 補上「path mode 也用它」（刻意不改名，避免波及 `install/compat.py` 與既有測試——最小必要變更）。
- `src/testpilot/cli.py`：`main` 改用 `PluginPathGroup`，覆寫 `resolve_command`。實作維持 **plugin 零具名**（`tests/test_cli_plugin_registration.py` 與 `test_core_has_no_plugin_names.py` 守門）。

## 驗證

**真實 plugin 端到端**（非只有合成 fixture）——對未安裝進本環境的 wifi_llapi 專案：

```console
$ python -m testpilot.cli /home/paul_chen/prj_arc/testpilot --help
Usage: python -m testpilot.cli wifi_llapi [OPTIONS]

  Run wifi_llapi tests.

Options:
  --case TEXT        Specific wifi_llapi case IDs to run.
  --dut-fw-ver TEXT  DUT firmware version used in report filename.
  --skip-preflight   Skip this run's pre-flight gate ...
  --help             Show this message and exit.

$ python -m testpilot.cli ../testpilot --help     # 相對路徑亦可
```

plugin 自有選項完整帶出，parity 確認。

**新增測試** `tests/test_cli_plugin_path_mode.py`（11 個）：

- 從專案路徑執行、plugin 自有選項轉發
- **同名碰撞**：installed 已在 `sys.modules`，path mode 仍須跑 on-disk 那份
- registry mode 未回歸（同一組 fixture 走 entry-point 路徑）
- 相對路徑
- 四種 fail-closed：路徑不存在、缺 pyproject、無 entry point、宣告多個
- `--help` 兩種形式、cli.py plugin 零具名守門

`python3 -m pytest -q` → **728 passed, 1 skipped**（baseline 717）。

## 文件

- `README.md`（en + zh 兩段）：兩種形式對照表、範例、path mode 細節。
- `docs/plugin-dev-guide.md`：補上「開發期免安裝跑法」——entry point 一寫好就能用 path mode 跑，不必先 `uv pip install -e .`；同時說明 `list-plugins` / `list-cases` 仍只列已安裝 plugin，故原驗證流程不變。
- R-16：`testpilot-help` / `testpilot-update-help` 兩個 marker 區塊已用 `scripts/policy_cli_help.sh` 重生。

## Release Notes Impact

- Type: feature
- Changelog: updated（`changelog.d/30-plugin-path-mode.md`，`type: feat`）
- Docs impact: README、docs/plugin-dev-guide.md
- CLI help sync: updated markers

## Validation

- `python3 -m pytest -q`（Python 3.12）→ **728 passed, 1 skipped**
- `preflight-ci`（policy_check 1.0.15 @ a764806）→ **PREFLIGHT PASS**（policy gate 全過；tests 步驟見下）
- ⚠️ 以 repo 的 `.venv/bin/python`（Python **3.11**）跑時，`tests/test_installer.py::TestOfflineInstall::test_offline_creates_wrapper` 失敗。**與本 PR 無關、且為既有問題**——已用 clean `main` 的 worktree 複驗，同樣失敗。根因是環境：測試 fixture 依當前直譯器建出 cp311 bundle，但 `install.sh` 內部取用 PATH 上的 `python3`（3.12），版本標籤不匹配。CI 單一直譯器環境不受影響
- `policy_check.changelog collate` 以 scratch 副本乾跑通過，fragment type 合法
- 真實 wifi_llapi 專案路徑端到端 smoke（絕對路徑 + 相對路徑）

## Checklist

- [x] Linked issue / problem statement is captured
- [x] `CHANGELOG.md` is updated for user-facing changes, or I explained why it is not needed
- [x] `README.md`, `docs/release-flow.md`, and/or `AGENTS.md` are updated when operator-facing behavior changed
- [x] `VERSION`, `pyproject.toml`, and `src/testpilot/__init__.py` were updated if this is a release-prep PR
- [x] README CLI help marker blocks declared in `.project-policy.yml` were refreshed when CLI help changed
- [x] Managed install/update/verify-install behavior was reviewed for release-impacting changes
- [x] Release workflow and policy checks were reviewed for release-prep PRs
- [x] Validation is recorded above
- [x] Release tag / release-notes impact was reviewed

Closes #30
