### PR TITLE
fix(runtime): serialwrap 非零 exit 例外訊息補上 stdout 摘要

### DIFF
--- a/changelog.d/33-serialwrap-stdout-error.md
+++ b/changelog.d/33-serialwrap-stdout-error.md
@@ -1,0 +1,14 @@
+---
+type: fix
+scope: transport
+issue: 33
+---
+serialwrap CLI 失敗時常把錯誤 JSON 印在 stdout（stderr 常為空），例如 daemon start
+被 systemd gate 拒絕時。`runtime/_serialwrap_log.py::_run_sw` 與
+`transport/serialwrap.py::_run_json` 在 `returncode != 0` 時原本只擷取 stderr 組成例外訊息，
+stdout 內容整包被丟掉，實地事故只看到「RuntimeError: serialwrap failed: daemon start: 」
+（冒號後空白），除錯資訊歸零。
+
+兩處改為在保留既有前綴與 stderr 內容不動的前提下（下游 wifi_llapi 以 substring 比對錯誤字串
+做分類，相容性不可破壞），於訊息結尾追加 `rc=<returncode>` 與截斷到 500 字的 stdout 摘要
+（stdout 為空時省略該段），讓 stdout 攜帶的錯誤細節不再遺失。

--- a/src/testpilot/runtime/_serialwrap_log.py
+++ b/src/testpilot/runtime/_serialwrap_log.py
@@ -43,7 +43,11 @@ def _run_sw(args: list[str], timeout: float = 10.0) -> dict[str, Any]:
     )
     if completed.returncode != 0:
         stderr = (completed.stderr or "").strip()
-        raise RuntimeError(f"serialwrap failed: {' '.join(args)}: {stderr}")
+        stdout_trimmed = (completed.stdout or "").strip()[:500]
+        suffix = f" | rc={completed.returncode}"
+        if stdout_trimmed:
+            suffix += f" | stdout={stdout_trimmed}"
+        raise RuntimeError(f"serialwrap failed: {' '.join(args)}: {stderr}{suffix}")
     stdout = (completed.stdout or "").strip()
     if not stdout:
         raise RuntimeError(f"serialwrap empty response: {' '.join(args)}")

--- a/src/testpilot/transport/serialwrap.py
+++ b/src/testpilot/transport/serialwrap.py
@@ -305,7 +305,13 @@ class SerialWrapTransport(TransportBase):
         )
         if completed.returncode != 0:
             stderr = (completed.stderr or "").strip()
-            raise RuntimeError(f"serialwrap command failed: {' '.join(args)}: {stderr}")
+            stdout_trimmed = (completed.stdout or "").strip()[:500]
+            suffix = f" | rc={completed.returncode}"
+            if stdout_trimmed:
+                suffix += f" | stdout={stdout_trimmed}"
+            raise RuntimeError(
+                f"serialwrap command failed: {' '.join(args)}: {stderr}{suffix}"
+            )
 
         stdout = (completed.stdout or "").strip()
         if not stdout:

--- a/tests/test_serialwrap_stdout_error.py
+++ b/tests/test_serialwrap_stdout_error.py
@@ -18,8 +18,18 @@ from testpilot.transport.serialwrap import SerialWrapTransport
 
 
 @pytest.fixture(autouse=True)
-def _set_serialwrap_bin(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SERIALWRAP_BIN", "/tmp/serialwrap")
+def _set_serialwrap_bin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # Hermetic binary resolution (review): a bare "/tmp/serialwrap" only works
+    # when that path (or a PATH-visible `serialwrap`) happens to exist on the
+    # host — resolve_serialwrap_binary() verifies existence before subprocess
+    # is ever reached. Materialise a fake executable so the test is
+    # self-contained on any machine/CI.
+    fake = tmp_path / "serialwrap"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("SERIALWRAP_BIN", str(fake))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_serialwrap_stdout_error.py
+++ b/tests/test_serialwrap_stdout_error.py
@@ -1,0 +1,128 @@
+"""Tests for issue #33: serialwrap non-zero exit errors must surface stdout.
+
+serialwrap CLI failures are frequently reported on stdout (as an error JSON
+payload) while stderr is empty — e.g. when systemd gates a daemon start.
+Both ``_run_sw`` (runtime/_serialwrap_log.py) and ``_run_json``
+(transport/serialwrap.py) previously only included stderr in the raised
+``RuntimeError``, silently dropping the stdout payload.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from testpilot.runtime import _serialwrap_log
+from testpilot.transport.serialwrap import SerialWrapTransport
+
+
+@pytest.fixture(autouse=True)
+def _set_serialwrap_bin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SERIALWRAP_BIN", "/tmp/serialwrap")
+
+
+# ---------------------------------------------------------------------------
+# runtime/_serialwrap_log.py::_run_sw
+# ---------------------------------------------------------------------------
+
+
+def test_run_sw_error_includes_stdout_when_stderr_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, capture_output, text, check, timeout):  # noqa: ANN001
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=2,
+            stdout='{"ok": false, "error_code": "DAEMON_GATE_DENIED"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(_serialwrap_log.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _serialwrap_log._run_sw(["daemon", "start"])
+
+    message = str(exc_info.value)
+    assert "DAEMON_GATE_DENIED" in message
+    assert "rc=2" in message
+
+
+def test_run_sw_error_keeps_stderr_prefix_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, capture_output, text, check, timeout):  # noqa: ANN001
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=1,
+            stdout="",
+            stderr="permission denied",
+        )
+
+    monkeypatch.setattr(_serialwrap_log.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _serialwrap_log._run_sw(["daemon", "start"])
+
+    message = str(exc_info.value)
+    assert message.startswith("serialwrap failed: daemon start: permission denied")
+
+
+# ---------------------------------------------------------------------------
+# transport/serialwrap.py::_run_json
+# ---------------------------------------------------------------------------
+
+
+def _make_transport(monkeypatch: pytest.MonkeyPatch) -> SerialWrapTransport:
+    monkeypatch.setattr(
+        "testpilot.transport.serialwrap.resolve_serialwrap_binary",
+        lambda configured_bin, *, config_label: str(configured_bin),
+    )
+    return SerialWrapTransport({"binary": "/tmp/serialwrap"})
+
+
+def test_run_json_error_includes_stdout_when_stderr_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _make_transport(monkeypatch)
+
+    def fake_run(args, capture_output, text, check, timeout):  # noqa: ANN001
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=2,
+            stdout='{"ok": false, "error_code": "DAEMON_GATE_DENIED"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr("testpilot.transport.serialwrap.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        transport._run_json(["daemon", "start"])
+
+    message = str(exc_info.value)
+    assert "DAEMON_GATE_DENIED" in message
+    assert "rc=2" in message
+
+
+def test_run_json_error_keeps_stderr_prefix_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _make_transport(monkeypatch)
+
+    def fake_run(args, capture_output, text, check, timeout):  # noqa: ANN001
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=1,
+            stdout="",
+            stderr="permission denied",
+        )
+
+    monkeypatch.setattr("testpilot.transport.serialwrap.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        transport._run_json(["daemon", "start"])
+
+    message = str(exc_info.value)
+    assert message.startswith(
+        "serialwrap command failed: daemon start: permission denied"
+    )


### PR DESCRIPTION
## Summary

- serialwrap CLI 非零 exit 時，`_run_sw`（`src/testpilot/runtime/_serialwrap_log.py`）與 `_run_json`（`src/testpilot/transport/serialwrap.py`）原本只把 stderr 併入 `RuntimeError` 訊息；但 serialwrap 常把錯誤 JSON 印在 **stdout**（stderr 為空，例如 daemon start 被 systemd gate 拒絕時），導致實地事故只看到「RuntimeError: serialwrap failed: daemon start: 」（冒號後空白），除錯資訊完全歸零。
- 兩處在保留既有前綴與 stderr 內容不變的前提下（下游 wifi_llapi 以 substring 比對錯誤字串做分類，相容性不可破壞），於訊息結尾追加 `rc=<returncode>` 與截斷至 500 字的 stdout 摘要（`| rc=... | stdout=...`），stdout 為空時省略該段。

Closes #33

## Release Notes Impact

- Type: fix
- Changelog: updated（`changelog.d/33-serialwrap-stdout-error.md` fragment，非直接改 `CHANGELOG.md`，依 fragment 模型於 release 時由 `collate` 併入）
- Docs impact: none（純內部錯誤訊息強化，無 operator-facing 行為/介面變動；README/docs/release-flow.md/AGENTS.md 均無引用到這兩個函式）
- CLI help sync: not affected

## Validation

- 新增 `tests/test_serialwrap_stdout_error.py`：涵蓋兩個檔案的錯誤路徑
  - rc=2、stdout 為 JSON 錯誤、stderr 空 → 例外訊息含 stdout 內容片段（`error_code`）與 `rc=2`
  - rc=2/1、stderr 有內容 → 例外訊息開頭仍是原本的 `"serialwrap failed: ..."` / `"serialwrap command failed: ..."` 前綴（向下相容）
- `/home/paul_chen/prj_arc/testpilot-core/.venv/bin/python -m pytest -q`（隔離 `SERIALWRAP_CONFIG_DIR`/`SERIALWRAP_STATE_DIR`）：735 passed, 1 skipped, 1 failed
  - 唯一失敗 `tests/test_installer.py::TestOfflineInstall::test_offline_creates_wrapper` 為既有環境問題（本機 Python 3.12 vs bundle 要求 cp311），與本次改動無關；已在未修改的 `main` 上重現同一失敗以確認 pre-existing。
- `python3 -m policy_check --repo .`：pass=25, fail=0, warn=1（R-22 pre-existing dangling references, advisory, 與本 PR 無關）。註：本機執行未帶 `--pr-*` context，僅供本地初驗。

## Checklist

- [x] Linked issue / problem statement is captured
- [x] `CHANGELOG.md` is updated for user-facing changes, or I explained why it is not needed
- [x] `README.md`, `docs/release-flow.md`, and/or `AGENTS.md` are updated when operator-facing behavior changed
- [x] `VERSION`, `pyproject.toml`, and `src/testpilot/__init__.py` were updated if this is a release-prep PR
- [x] README CLI help marker blocks declared in `.project-policy.yml` were refreshed when CLI help changed
- [x] Managed install/update/verify-install behavior was reviewed for release-impacting changes
- [x] Release workflow and policy checks were reviewed for release-prep PRs
- [x] Validation is recorded above
- [x] Release tag / release-notes impact was reviewed

（本 PR 非 release-prep PR，故 VERSION/pyproject/__init__、CLI help marker、release workflow 等項目經檢視後判定不適用/無需變動，一併勾選並於此註記。）
