### PR TITLE
fix(runtime): daemon_status 未知時 setup_run 不得 rmtree WAL 目錄（#36）

### DIFF
--- a/changelog.d/36-clean-wal-safety.md
+++ b/changelog.d/36-clean-wal-safety.md
@@ -1,0 +1,24 @@
+---
+type: fix
+scope: runtime
+issue: 36
+---
+`SerialwrapBackend.setup_run()` 在 `daemon_status()` 回 `None` 時，原本會呼叫
+`_serialwrap_log.clean_wal()` 對硬編路徑 `/tmp/serialwrap/wal` 直接 `shutil.rmtree`
+再啟動 daemon。實地事故顯示「`daemon_status()` 回 `None`」最常見的原因是 client
+連不到 daemon（daemon 其實還活著），因此這段邏輯會刪掉正在跑的 daemon 仍在寫入的
+WAL 目錄；daemon 對已被 unlink 的 fd 繼續寫入，遠端 bench 因此連續 6 天遺失 console
+稽核紀錄（見 hamanpaul/serialwrap#173、#171）。
+
+修法：`setup_run()` 的該分支移除 `clean_wal()` 呼叫，改為 `start_daemon()` 之後
+best-effort 呼叫 `wal_reset()`（try/except，失敗只 log warning，不中斷
+`setup_run()`）；WAL 輪替一律走 daemon 自身的 RPC `wal reset`（daemon 端保留歸檔），
+不再由 client 端對 WAL 目錄做本地刪除。同步移除 `_serialwrap_log.clean_wal()` 與
+`DEFAULT_WAL_DIR` 常數（repo 內確認無其他呼叫者）；`get_wal_path()` 原本共用
+`DEFAULT_WAL_DIR` 組出的 fallback 路徑改為獨立的 `_WAL_PATH_FALLBACK`
+私有常數 —— 僅供 daemon_status 拿不到 `wal_path` 時的顯示/紀錄用途，不再作為任何
+刪除操作的目標路徑，`get_wal_path()` 的回傳型別與呼叫端行為維持不變。
+
+新增回歸測試涵蓋：daemon 狀態未知分支不再呼叫 `shutil.rmtree`、`start_daemon()`
+仍會被呼叫、成功後會呼叫 `wal_reset()`，以及 `wal_reset()` 拋例外時 `setup_run()`
+不中斷且仍回傳可用的 `RunHandle`。

--- a/src/testpilot/runtime/_serialwrap_log.py
+++ b/src/testpilot/runtime/_serialwrap_log.py
@@ -92,7 +92,15 @@ def stop_daemon() -> None:
 
 
 def daemon_status() -> dict[str, Any] | None:
-    """Return daemon status dict, or None if daemon is not running."""
+    """Return daemon status dict, or None when status is unavailable.
+
+    ``None`` only means this client could not obtain a status — the daemon
+    may genuinely not be running, **or** it may be alive but unreachable
+    from here (mismatched socket path, permissions, transient failure).
+    Callers must NOT treat ``None`` as proof the daemon is down, and in
+    particular must never use it to justify destructive cleanup of daemon
+    state (that misread is exactly how issue #36 destroyed a live WAL).
+    """
     try:
         return _run_sw(["daemon", "status"], timeout=5.0)
     except Exception:
@@ -210,7 +218,13 @@ def setup_sessions(
 # ---------------------------------------------------------------------------
 
 def get_wal_path() -> Path:
-    """Return the WAL ndjson file path from daemon status."""
+    """Return the WAL ndjson file path, preferring the daemon-reported one.
+
+    Asks ``daemon status`` first; when that is unavailable (or carries no
+    ``wal_path``), falls back to the historical default location
+    (``_WAL_PATH_FALLBACK``) purely for display/logging purposes — the
+    returned path is NOT guaranteed to be the live daemon's actual WAL.
+    """
     status = daemon_status()
     if status and status.get("wal_path"):
         return Path(status["wal_path"])

--- a/src/testpilot/runtime/_serialwrap_log.py
+++ b/src/testpilot/runtime/_serialwrap_log.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -15,7 +14,11 @@ from testpilot.serialwrap_binary import resolve_serialwrap_binary
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_WAL_DIR = Path("/tmp/serialwrap/wal")
+# get_wal_path() 的 best-effort 顯示用 fallback（daemon_status() 拿不到
+# wal_path 時才會用到）。這**不是**刪除/清理操作的目標路徑 —— #36 之後
+# WAL 目錄的清理/輪替只能透過 daemon 自己的 RPC `wal reset` 進行，本檔
+# 不再對任何 WAL 路徑做本地 rmtree。
+_WAL_PATH_FALLBACK = Path("/tmp/serialwrap/wal/raw.wal.ndjson")
 
 _configured_bin: str | None = None
 
@@ -94,14 +97,6 @@ def daemon_status() -> dict[str, Any] | None:
         return _run_sw(["daemon", "status"], timeout=5.0)
     except Exception:
         return None
-
-
-def clean_wal(wal_dir: Path | None = None) -> None:
-    """Remove old WAL files so next daemon start has a clean slate."""
-    target = wal_dir or DEFAULT_WAL_DIR
-    if target.is_dir():
-        shutil.rmtree(target, ignore_errors=True)
-        logger.info("cleaned WAL directory: %s", target)
 
 
 def wal_reset() -> dict[str, Any]:
@@ -219,7 +214,7 @@ def get_wal_path() -> Path:
     status = daemon_status()
     if status and status.get("wal_path"):
         return Path(status["wal_path"])
-    return DEFAULT_WAL_DIR / "raw.wal.ndjson"
+    return _WAL_PATH_FALLBACK
 
 
 def get_current_seq(wal_path: Path | None = None) -> int | None:

--- a/src/testpilot/runtime/serialwrap_backend.py
+++ b/src/testpilot/runtime/serialwrap_backend.py
@@ -74,9 +74,21 @@ class SerialwrapBackend(RunBackend):
                     status.get("pid"),
                 )
             else:
+                # daemon_status() 回 None 最常見的原因是 client 連不到「其實還活著」的
+                # daemon（而非真的沒有 daemon）。因此這裡不可再對 WAL 目錄做本地
+                # rmtree —— 那會刪掉存活 daemon 仍在寫入的檔案（#36）。start_daemon()
+                # 對已在跑的 daemon 是 no-op/冪等；之後改走 RPC wal_reset()
+                # 做輪替（daemon 自己保留歸檔，安全），且僅為 best-effort。
                 started_fresh = True
-                _serialwrap_log.clean_wal()
                 _serialwrap_log.start_daemon()
+                try:
+                    _serialwrap_log.wal_reset()
+                except Exception:
+                    log.warning(
+                        "serialwrap wal_reset after start_daemon failed; "
+                        "continuing without WAL rotation",
+                        exc_info=True,
+                    )
                 wal_path = _serialwrap_log.get_wal_path()
                 log.info("serialwrap daemon started, wal_path=%s", wal_path)
             return RunHandle(

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -213,16 +213,6 @@ class TestDaemonLifecycle:
     def test_stop_daemon_ignores_error(self, mock_run):
         log_capture.stop_daemon()  # should not raise
 
-    def test_clean_wal(self, tmp_path: Path):
-        wal_dir = tmp_path / "wal"
-        wal_dir.mkdir()
-        (wal_dir / "old.ndjson").write_text("data")
-        log_capture.clean_wal(wal_dir)
-        assert not wal_dir.exists()
-
-    def test_clean_wal_missing_dir(self, tmp_path: Path):
-        log_capture.clean_wal(tmp_path / "nonexistent")  # should not raise
-
     @patch("testpilot.runtime._serialwrap_log._run_sw")
     @patch("testpilot.runtime._serialwrap_log.subprocess.Popen")
     def test_setup_sessions(self, mock_popen, mock_run):

--- a/tests/test_orchestrator_serialwrap_logs.py
+++ b/tests/test_orchestrator_serialwrap_logs.py
@@ -141,7 +141,6 @@ def test_start_run_capture_reraises_body_typeerror() -> None:
 
 def test_serialwrap_backend_setup_run_degrades_when_start_daemon_fails(monkeypatch) -> None:
     monkeypatch.setattr(_serialwrap_log, "daemon_status", lambda: None)
-    monkeypatch.setattr(_serialwrap_log, "clean_wal", lambda *args, **kwargs: None)
 
     def fail_start(*args, **kwargs):
         raise RuntimeError("daemon start failed")
@@ -154,6 +153,85 @@ def test_serialwrap_backend_setup_run_degrades_when_start_daemon_fails(monkeypat
     assert handle.run_id == "run-1"
     assert handle.meta.get("bind_sessions") is False
     assert handle.meta.get("wal_path") is None
+
+
+def test_serialwrap_backend_setup_run_never_rmtrees_wal_when_status_unknown(monkeypatch) -> None:
+    """Issue #36 regression.
+
+    daemon_status() returning None most commonly means the client failed to
+    reach an *already-running* daemon (not that no daemon exists at all).
+    setup_run's degraded-status branch must never delete the WAL directory —
+    only start_daemon() then a best-effort RPC wal_reset() (daemon-owned
+    rotation with archiving), never a local rmtree.
+    """
+    monkeypatch.setattr(_serialwrap_log, "daemon_status", lambda: None)
+
+    rmtree_calls: list[Any] = []
+    monkeypatch.setattr(
+        "shutil.rmtree",
+        lambda *args, **kwargs: rmtree_calls.append((args, kwargs)),
+    )
+
+    start_daemon_calls: list[Any] = []
+    monkeypatch.setattr(
+        _serialwrap_log,
+        "start_daemon",
+        lambda *args, **kwargs: start_daemon_calls.append((args, kwargs)) or {"pid": 1},
+    )
+
+    wal_reset_calls: list[Any] = []
+    monkeypatch.setattr(
+        _serialwrap_log,
+        "wal_reset",
+        lambda: wal_reset_calls.append(True) or {"previous_seq": 0},
+    )
+    monkeypatch.setattr(
+        _serialwrap_log,
+        "get_wal_path",
+        lambda: Path("/tmp/serialwrap/wal/raw.wal.ndjson"),
+    )
+
+    backend = SerialwrapBackend()
+    handle = backend.setup_run("run-1", {})
+
+    assert rmtree_calls == []
+    assert len(start_daemon_calls) == 1
+    assert len(wal_reset_calls) == 1
+    assert handle.run_id == "run-1"
+    assert handle.meta.get("bind_sessions") is True
+    assert handle.meta.get("wal_path") == "/tmp/serialwrap/wal/raw.wal.ndjson"
+
+
+def test_serialwrap_backend_setup_run_survives_wal_reset_failure_after_fresh_start(
+    monkeypatch,
+) -> None:
+    """wal_reset() after a fresh start_daemon() is best-effort: an RPC failure
+    (daemon still settling) must not abort setup_run or drop the RunHandle."""
+    monkeypatch.setattr(_serialwrap_log, "daemon_status", lambda: None)
+    monkeypatch.setattr(
+        "shutil.rmtree",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("rmtree must never be called from setup_run")
+        ),
+    )
+    monkeypatch.setattr(_serialwrap_log, "start_daemon", lambda *a, **k: {"pid": 1})
+
+    def failing_wal_reset() -> dict[str, Any]:
+        raise RuntimeError("daemon not ready for wal reset yet")
+
+    monkeypatch.setattr(_serialwrap_log, "wal_reset", failing_wal_reset)
+    monkeypatch.setattr(
+        _serialwrap_log,
+        "get_wal_path",
+        lambda: Path("/tmp/serialwrap/wal/raw.wal.ndjson"),
+    )
+
+    backend = SerialwrapBackend()
+    handle = backend.setup_run("run-1", {})
+
+    assert handle.run_id == "run-1"
+    assert handle.meta.get("bind_sessions") is True
+    assert handle.meta.get("wal_path") == "/tmp/serialwrap/wal/raw.wal.ndjson"
 
 
 def test_serialwrap_backend_mark_position_reads_explicit_wal_tail(


### PR DESCRIPTION
## Summary

- `SerialwrapBackend.setup_run()` 在 `daemon_status()` 回 `None` 時，原本會呼叫 `_serialwrap_log.clean_wal()` 對硬編路徑 `/tmp/serialwrap/wal` 直接 `shutil.rmtree` 再啟動 daemon。實地事故顯示「`daemon_status()` 回 `None`」最常見的原因是 client 連不到 daemon（daemon 其實還活著），而非真的沒有 daemon——遠端 bench 因此被 rmtree 掉運行中 daemon 的 WAL 目錄，daemon 對已 unlink 的 fd 繼續寫了 6 天，稽核紀錄全毀（跨 repo 脈絡：hamanpaul/serialwrap#173、#171）。
- 修法：`setup_run()` 的該分支移除 `clean_wal()` 呼叫，改為 `start_daemon()` 之後 best-effort 呼叫 `wal_reset()`（RPC，daemon 自己輪替並保留歸檔；try/except，失敗只 log warning，不中斷 `setup_run()`）。
- 同步移除 `_serialwrap_log.clean_wal()` 與 `DEFAULT_WAL_DIR` 常數（repo 內確認無其他呼叫者）；`get_wal_path()` 原本共用 `DEFAULT_WAL_DIR` 組出的顯示用 fallback 路徑改為獨立的私有常數 `_WAL_PATH_FALLBACK`——僅供 `daemon_status()` 拿不到 `wal_path` 時的顯示/紀錄用途，不再作為任何刪除操作的目標路徑；`get_wal_path()` 的回傳型別與呼叫端行為維持不變。

## Release Notes Impact

- Type: fix
- Changelog: updated（`changelog.d/36-clean-wal-safety.md`）
- Docs impact: none（純 runtime 內部行為修正，無操作者可見介面/行為變更；`docs/superpowers/plans|specs/2026-06-18-serialwrap-runbackend-abstraction*.md` 為歷史設計草案文件，且屬 R-22 內建排除範圍 `docs/superpowers/`，不隨本次程式變更同步）
- CLI help sync: not affected

## Validation

- `SERIALWRAP_CONFIG_DIR=$(mktemp -d) SERIALWRAP_STATE_DIR=$(mktemp -d) .venv/bin/python -m pytest -q tests/test_orchestrator_serialwrap_logs.py tests/test_log_capture.py` → 41 passed
- `SERIALWRAP_CONFIG_DIR=$(mktemp -d) SERIALWRAP_STATE_DIR=$(mktemp -d) .venv/bin/python -m pytest -q`（完整套件）→ 731 passed, 1 failed, 1 skipped。唯一失敗 `tests/test_installer.py::TestOfflineInstall::test_offline_creates_wrapper` 為本機環境 cp311 bundle vs. 本機 python 3.12 版本不符，與本 PR 改動無關；已在 `main` 上重現同一失敗，確認為 pre-existing。
- `python3 -m policy_check --repo .` → 25 pass / 0 fail / 1 warn（R-22：93 個 pre-existing dangling reference，皆與本次改動無關，advisory 不擋 merge；本機執行未帶 PR context，R-09/R-18 因而顯示「No code path files changed」，屬已知落差，見 repo 慣例記錄）

## Checklist

- [x] Linked issue / problem statement is captured
- [x] `CHANGELOG.md` is updated for user-facing changes, or I explained why it is not needed
- [x] `README.md`, `docs/release-flow.md`, and/or `AGENTS.md` are updated when operator-facing behavior changed
- [x] `VERSION`, `pyproject.toml`, and `src/testpilot/__init__.py` were updated if this is a release-prep PR
- [x] README CLI help marker blocks declared in `.project-policy.yml` were refreshed when CLI help changed
- [x] Managed install/update/verify-install behavior was reviewed for release-impacting changes
- [x] Release workflow and policy checks were reviewed for release-prep PRs
- [x] Validation is recorded above
- [x] Release tag / release-notes impact was reviewed

> 註：本 PR 非 release-prep PR、未改動 CLI help/README/`docs/release-flow.md`/`AGENTS.md`/`VERSION`；上列對應項目已逐一確認「無需變更」後勾選。

Closes #36
