### PR TITLE
docs(positioning): align TestPilot Core framework description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Fact:** `testpilot-core` 是 embedded test verdict 的唯一 authority，負責 deterministic test execution、evidence collection 與 pass / fail 判定；Agent intervention 不構成 gate 通過證明。
+> **Scope:** `testpilot-core` is the host framework for plugin-based test verification. On the core-owned execution path it orchestrates the test lifecycle, records evidence and traces, and preserves the canonical verdict produced through plugin evaluation. Plugins define project-specific cases, environment operations, and evaluation semantics. Agent intervention is optional and is never, by itself, proof that a verification gate passed.
 
 # TestPilot
 
@@ -10,13 +10,15 @@
 
 ## Install
 
-This README is the canonical install reference. For online install (managed venv, newest API-compatible core/plugins; serialwrap pinned), see [Quick Start](#quick-start). For offline environments or update procedures, see [Managed Install and Update](#managed-install-and-update). After any install or update, run `testpilot --verify-install` to confirm health.
+This README is the canonical install reference. For the maintainer-oriented managed install, see [Quick Start](#quick-start) and [Managed Install and Update](#managed-install-and-update). For plugin development, registry mode and path mode are both supported; path mode can run a plugin project directly without installing that plugin first.
+
+After a managed install or update, run `testpilot --verify-install` to confirm health.
 
 ## Usage
 
-`testpilot` is the host runtime; test capabilities are provided by plugins.
-Use `testpilot list-plugins` to see installed plugins and `testpilot run <plugin>`
-to drive them.
+`testpilot` is the host runtime. Test capabilities are supplied by plugins developed for each project.
+
+Use `testpilot list-plugins` to see installed plugins and `testpilot run <plugin>` to drive the generic core run path when the plugin does not expose its own command.
 
 A plugin can be selected two ways:
 
@@ -31,104 +33,99 @@ testpilot /path/to/my_plugin --case D001  # path mode, same plugin command
 testpilot ../my_plugin                    # relative paths work too
 ```
 
-Both forms dispatch to the same plugin-owned command, so plugin-specific options
-behave identically. Path mode details:
+Both forms dispatch to the same plugin-owned command, so plugin-specific options behave identically. Path mode details:
 
-- `PLUGIN_PATH` is the **project root** — the directory containing
-  `pyproject.toml` with a `[project.entry-points."testpilot.plugins"]` table.
-  That table is the single source of truth for the plugin's name and import
-  target, so both modes agree on identity.
-- The project must declare exactly one plugin. More than one is refused rather
-  than guessed; install the project and select by name instead.
-- The project copy wins over an installed distribution of the same name, even
-  when that distribution is already imported. If the declared module still
-  resolves outside the requested project, the run is refused rather than
-  silently testing the wrong tree.
-- Path mode does not skip the SDK API-version gate — an incompatible plugin is
-  rejected exactly as in registry mode.
-- A registered plugin name always takes precedence over a same-named directory
-  in the working directory, so path mode can never shadow an installed plugin.
-- A token is read as a path when it contains a separator, starts with `.` or
-  `~`, or names an existing directory. Anything else is treated as a plugin
-  name or subcommand.
+- `PLUGIN_PATH` is the **project root** — the directory containing `pyproject.toml` with a `[project.entry-points."testpilot.plugins"]` table. That table is the single source of truth for the plugin's name and import target, so both modes agree on identity.
+- The project must declare exactly one plugin. More than one is refused rather than guessed; install the project and select by name instead.
+- The project copy wins over an installed distribution of the same name, even when that distribution is already imported. If the declared module still resolves outside the requested project, the run is refused rather than silently testing the wrong tree.
+- Path mode does not skip the SDK API-version gate — an incompatible plugin is rejected exactly as in registry mode.
+- A registered plugin name always takes precedence over a same-named directory in the working directory, so path mode cannot shadow an installed plugin by accident.
+- A token is read as a path when it contains a separator, starts with `.` or `~`, or names an existing directory. Anything else is treated as a plugin name or subcommand.
 
 ## Version
 
 The canonical project version is `VERSION`; release tags use `vX.Y.Z`.
-`testpilot --version` also inventories every installed `testpilot.plugins`
-entry point so operators can see the effective core/plugin/API combination:
+`testpilot --version` also inventories every installed `testpilot.plugins` entry point so operators can see the effective core/plugin/API combination:
 
 ```text
 TestPilot <core-version> (<source-ref>)
-  plugin wifi_llapi <plugin-version> (api <api-version>)
+  plugin <name> <plugin-version> (api <api-version>)
 ```
 
 ---
 
 ## English
 
-Plugin-based test automation framework for embedded device verification (prplOS / OpenWrt).
+**TestPilot Core is a plugin-based test automation and verification framework.**
 
-This repository is **TestPilot core**: the deterministic verdict kernel, the
-plugin SDK (`testpilot.api`), the CLI host, transports, schema, and reporting.
-It ships the plugin scaffold under `plugins/_template/` but no concrete test
-plugins. Real plugins (for example `wifi_llapi` and `brcm_fw_upgrade`) live in
-their own repositories and register themselves through the
-`testpilot.plugins` entry-point group.
+It provides a versioned plugin SDK (`testpilot.api`), CLI host, lifecycle orchestration, evidence/trace capture, reporting contracts, transport/run-backend abstractions, and an optional agent-assisted control plane. Project-specific test logic belongs in independently developed plugins.
 
-### Overview
+### Scope and current fit
 
-TestPilot is a plugin-based test automation framework for prplOS / OpenWrt embedded devices. The architecture splits into two planes:
+The core extension model is not tied to a single product domain, but the project has an embedded and real-hardware testing heritage. Current field usage, bundled transport support, managed-install assumptions, and most non-trivial examples are still concentrated around device verification.
 
-- **Deterministic verdict kernel** — test execution, evidence collection, pass/fail verdicts, and report projection.
-- **Copilot SDK control plane** — per-case session foundation, lifecycle hooks, advisory audit, tiered environment recovery, and extension surfaces such as custom agents / skills / selective MCP.
+That means two things at the same time:
 
-Core principle: **the Copilot SDK handles the control plane; it does NOT decide the final verdict.**
+- TestPilot Core should not be described as an embedded-only framework; a project can provide its own plugin, cases, environment logic, runner, reporter, and integrations through the public SDK.
+- TestPilot Core also does **not** claim ready-made support for arbitrary domains. Outside the currently exercised device/real-hardware workflows, adopters are expected to supply and validate their own plugin integration.
 
-Current landed control-plane subset today:
+The core wheel does not ship a domain test suite. Public references currently include:
+
+- `examples/sample_echo/` — a zero-hardware, runnable SDK example that demonstrates packaging, discovery, execution, verdict production, and a plugin-owned CLI.
+- [`serialwrap_reliability`](https://github.com/hamanpaul/serialwrap/tree/main/reliability) — a hardware-backed TestPilot integration used to exercise serialwrap reliability workflows. It lives in the public `serialwrap` repository and is maintained separately from the core.
+
+### Architecture
+
+The default core-owned execution path is split into two concerns:
+
+- **Deterministic verdict kernel** — lifecycle execution, evidence collection, retry/timeout handling, canonical trace/result production, and report handoff. The domain-specific pass/fail semantics still come from the plugin's `evaluate()` implementation.
+- **Copilot SDK control plane** — per-case session foundation, lifecycle hooks, advisory planning, tiered environment recovery, and extension surfaces such as custom agents / skills / selective MCP.
+
+Core principle: **agent assistance does not own the final verdict.**
+
+Current landed control-plane subset:
 
 - per-case runner selection with `selection_trace`
 - best-effort per-case Copilot session foundation
 - lifecycle hook dispatch (`pre_case`, `post_case`, `pre_step`, `post_step`, `on_failure`, `on_retry`)
 - advisory collection plus tier-1 deterministic remediation and opt-in tier-2 one-shot planning between retry attempts
 
-Tier-2 is reached only after the configured consecutive tier-1 failures. Core
-builds a bounded, tool-denied one-shot prompt from the plugin's advertised
-environment capabilities; the plugin executes the validated plan, then core
-forces deterministic `verify_env`. The agent never receives verdict authority
-or permission to rewrite case semantics. Every intervention is marked
-`agent_recovered` and retained in bounded/redacted case and run audit artifacts;
-the marker means the agent intervened, not that the verification gate passed.
+Tier-2 is reached only after the configured consecutive tier-1 failures. Core builds a bounded, tool-denied one-shot prompt from the plugin's advertised environment capabilities; the plugin executes the validated plan, then core forces deterministic `verify_env`. The agent does not receive authority to rewrite case semantics or the canonical verdict. Every intervention is marked `agent_recovered` and retained in bounded/redacted case and run audit artifacts; the marker means the agent intervened, not that the verification gate passed.
+
 See [Tier-2 Environment Recovery Design](docs/superpowers/specs/2026-07-17-tier2-env-recovery-design.md).
 
 Custom agents / skills / MCP remain extension surfaces in the current codebase rather than default hot-path runtime wiring.
 
+> Plugins may also provide a custom runner. That is an intentional extension path; custom runners own more of their execution pipeline and do not automatically receive every core-owned analysis path. The framework therefore distinguishes the default **core-owned execution path** from plugin-owned custom execution.
+
 ### Prerequisites
+
+Core / SDK development:
 
 - **Python 3.11+**
 - **git**
-- **[uv](https://docs.astral.sh/uv/)** — Python package manager, preferred by the installer
-- **[serialwrap](https://github.com/hamanpaul/serialwrap)** — UART serial multiplexer for DUT / STA communication; managed installs install/update it automatically
+- **[uv](https://docs.astral.sh/uv/)** — preferred package manager for this repository
 
-Developer checkouts that manage serialwrap manually can still set the binary path via environment variable:
+Workflow-specific dependencies are plugin-owned. In particular, [`serialwrap`](https://github.com/hamanpaul/serialwrap) is required by the existing UART/device workflows and is pinned by the current managed-install profile, but it is not a conceptual requirement for every possible TestPilot plugin. The `sample_echo` reference runs without hardware.
+
+Developer checkouts that use serialwrap and manage it manually can set the binary path with an environment variable:
 
 ```bash
 export SERIALWRAP_BIN=/path/to/serialwrap
 ```
 
-Or add to `configs/testbed.yaml`:
+or in `configs/testbed.yaml`:
 
 ```yaml
 testbed:
   serialwrap_binary: /path/to/serialwrap
 ```
 
-> Resolution order: `SERIALWRAP_BIN` env var → `testbed.yaml` config → error exit.
+> Current serialwrap resolution order: `SERIALWRAP_BIN` env var → `testbed.yaml` config → error exit when a serialwrap-backed workflow requires it.
 
 ### Quick Start
 
-**Online one-click install** (requires a fine-grained read-only PAT with `contents: read`
-for `hamanpaul/testpilot-core` and all plugin repos):
+The repository's managed installer is designed around the maintainer's current QC/TEST deployment profile. It resolves the core plus the plugin repositories declared in `install-manifest.yaml`, and therefore may require credentials for non-public plugin repositories present in that manifest.
 
 ```bash
 TESTPILOT_INSTALL_TOKEN=<fine-grained read-only PAT> bash scripts/install.sh
@@ -136,13 +133,20 @@ testpilot --verify-install
 testpilot list-plugins
 ```
 
-Install only a subset of plugins with `--plugins`:
+Install only a selected manifest plugin with `--plugins`:
 
 ```bash
-TESTPILOT_INSTALL_TOKEN=<PAT> bash scripts/install.sh --plugins wifi_llapi
+TESTPILOT_INSTALL_TOKEN=<PAT> bash scripts/install.sh --plugins <plugin_name>
 ```
 
-Once installed, list and run plugins:
+For external plugin development, it is usually simpler to install TestPilot Core in a development environment and either install the plugin package normally or run the plugin checkout with path mode:
+
+```bash
+testpilot /path/to/my_plugin --help
+testpilot /path/to/my_plugin
+```
+
+Once installed, list and run registry plugins:
 
 ```bash
 testpilot list-plugins
@@ -150,19 +154,11 @@ testpilot list-cases <plugin>
 testpilot run <plugin>
 ```
 
-> When a plugin context is resolved, the CLI auto-stages
-> `plugins/<plugin>/testbed.yaml.example` into `configs/testbed.yaml`, so each run
-> starts from that plugin's shipped testbed shape with no leakage between
-> plugins. Edit `configs/testbed.yaml` to match your lab — note that switching
-> to a different plugin will overwrite it.
+> When a plugin context is resolved through the generic core path, the CLI stages that plugin's `testbed.yaml.example` into `configs/testbed.yaml`. The current implementation overwrites the effective file when switching plugin contexts; treat the plugin template as the source used for staging and keep project-specific configuration under version control in the plugin project rather than assuming the staged file is persistent.
 
 ### Managed Install and Update
 
-The supported QC/TEST install uses a managed venv (no git checkout). Online
-install resolves the **newest API-compatible** `core` and plugin releases;
-`serialwrap` stays pinned in `install-manifest.yaml`. An offline bundle is an
-exact, SHA256-verified snapshot. Pin any component explicitly with
-`--plugins <name>@<version>` (or by adding a `version:` back to the manifest):
+The supported QC/TEST install uses a managed venv. Online install resolves the **newest API-compatible** `core` and declared plugin releases; `serialwrap` stays pinned in `install-manifest.yaml`. An offline bundle is an exact, SHA256-verified snapshot. Pin a component explicitly with `--plugins <name>@<version>` or with a manifest version when needed.
 
 ```bash
 ~/.local/share/testpilot/.venv   # managed runtime virtualenv
@@ -170,14 +166,13 @@ exact, SHA256-verified snapshot. Pin any component explicitly with
 ~/.agents/skills/testpilot-normal-test
 ```
 
-**Online install** — downloads wheels via `gh release download` using a fine-grained PAT:
+**Online install:**
 
 ```bash
 TESTPILOT_INSTALL_TOKEN=<fine-grained read-only PAT> bash scripts/install.sh
 ```
 
-**Offline install** — build a bundle on a networked Linux box with `scripts/build-bundle.sh`,
-then transfer and install on the air-gapped machine:
+**Offline install:** build a bundle on a networked Linux machine with `scripts/build-bundle.sh`, then transfer and install it on the target machine.
 
 ```bash
 # Build on a networked machine:
@@ -190,26 +185,17 @@ bash scripts/install.sh --offline testpilot-bundle-<ver>-linux-<arch>-cp<XY>.tar
 **Update and verify:**
 
 ```bash
-testpilot --update            # reinstalls newest-compatible core/plugins (serialwrap pinned), reconciles plugins
-testpilot --verify-install    # report install health
+testpilot --update            # reinstall/reconcile the current manifest-managed set
+testpilot --verify-install    # report managed install health
 ```
 
-`--update` snapshots the environment first; if the post-update verify fails it
-rolls back **offline only** (`pip install --no-index --find-links` against the
-local wheel cache the installer preserves under
-`${TESTPILOT_HOME:-~/.local/share/testpilot}/.wheel-cache`) — it never reaches a
-public index. If the cached wheels are insufficient, rollback fails loudly and
-asks you to reinstall from a known-good bundle via `install.sh --offline`.
+`--update` snapshots the environment first. If the post-update verification fails, rollback uses only the local wheel cache under `${TESTPILOT_HOME:-~/.local/share/testpilot}/.wheel-cache`; it does not fall back to a public package index. If the cached wheels are insufficient, rollback fails loudly and asks for reinstall from a known-good offline bundle.
 
 ### CLI Entry Points
 
-Use the installed `testpilot` command for normal operation. Developer checkouts can
-still use `python -m testpilot.cli` when debugging the repository.
+Use the installed `testpilot` command for normal operation. Developer checkouts can still use `python -m testpilot.cli` when debugging the repository.
 
-Plugin-owned CLI commands are registered from installed plugin packages when
-`testpilot.cli` is imported. `--root <path>` selects the runtime project root for
-cases/configs/reports; it does not dynamically replace the registered plugin CLI
-surface with commands from `<path>/plugins`.
+Plugin-owned CLI commands are registered from installed plugin packages when `testpilot.cli` is imported. `--root <path>` selects the runtime project root for cases/configs/reports; it does not dynamically replace the registered plugin CLI surface with commands from `<path>/plugins`.
 
 The core host commands are:
 
@@ -224,7 +210,7 @@ testpilot run <plugin>
 <!-- BEGIN: cli-help marker="testpilot-help" -->
 Usage: testpilot [OPTIONS] COMMAND [ARGS]...
 
-  TestPilot — plugin-based test automation for embedded devices.
+  TestPilot — plugin-based test automation and verification framework.
 
   A plugin can be selected two ways:
     testpilot <PLUGIN_NAME> [ARGS]...  registry mode — an installed plugin,
@@ -263,7 +249,7 @@ Commands:
 <!-- BEGIN: cli-help marker="testpilot-update-help" -->
 Usage: testpilot [OPTIONS] COMMAND [ARGS]...
 
-  TestPilot — plugin-based test automation for embedded devices.
+  TestPilot — plugin-based test automation and verification framework.
 
   A plugin can be selected two ways:
     testpilot <PLUGIN_NAME> [ARGS]...  registry mode — an installed plugin,
@@ -302,11 +288,7 @@ Repository skills for agent-assisted workflows live under `skills/`.
 
 ### Azure OpenAI (BYOK)
 
-TestPilot core automatically uses Azure when all required values are present.
-Without an API key it runs in deterministic/no-agent mode; a key without an
-endpoint or deployment produces a non-blocking misconfiguration notice. If
-`COPILOT_PROVIDER_TYPE` is set to a non-`azure` value, core also treats the
-runtime as misconfigured and emits the same redacted notice.
+TestPilot Core automatically uses Azure when all required values are present. Without an API key it runs in deterministic/no-agent mode; a key without an endpoint or deployment produces a non-blocking misconfiguration notice. If `COPILOT_PROVIDER_TYPE` is set to a non-`azure` value, core also treats the runtime as misconfigured and emits the same redacted notice.
 
 ```bash
 export COPILOT_PROVIDER_BASE_URL=https://your-resource.openai.azure.com
@@ -316,14 +298,7 @@ export COPILOT_PROVIDER_AZURE_API_VERSION=2024-10-21
 testpilot run <plugin_name>
 ```
 
-`COPILOT_PROVIDER_TYPE` is not an enable switch; core constructs only the Azure
-provider and rejects non-azure values as misconfiguration. Azure deployment
-selection is independent of plugin runner labels. Per-case planning is
-advisory, tier-2 recovery requires plugin opt-in, and deterministic remediation
-remains plugin-owned. Core-owned usage and observational benefit metrics are
-written under `artifact_dir/agent_usage`; shared run-analysis tokens are not
-allocated to cases. Custom/skeleton runners report `unsupported_execution_path`
-and make no core model calls.
+`COPILOT_PROVIDER_TYPE` is not an enable switch; core constructs only the Azure provider and rejects non-azure values as misconfiguration. Azure deployment selection is independent of plugin runner labels. Per-case planning is advisory, tier-2 recovery requires plugin opt-in, and deterministic remediation remains plugin-owned. Core-owned usage and observational benefit metrics are written under `artifact_dir/agent_usage`; shared run-analysis tokens are not allocated to cases. Custom/skeleton runners report `unsupported_execution_path` and make no core model calls.
 
 ### Writing a Plugin
 
@@ -343,17 +318,11 @@ uv pip install -e .
 testpilot list-plugins
 ```
 
-Implement the `PluginBase` contract (declare `api_version`, `name`,
-`discover_cases()`, `execute_step()`, `evaluate()`; override optional hooks such
-as `setup_env()`, `verify_env()`, `teardown()`, `create_reporter()`,
-`create_runner()`, and `register_cli()` as needed). Plugins import the public
-SDK surface from `testpilot.api`; they must not reach into `testpilot.core`,
-`testpilot.schema`, `testpilot.reporting`, `testpilot.transport`, or
-`testpilot.runtime` internals. See `plugins/_template/README.md` for the full
-contract and optional hook table.
+Implement the `PluginBase` contract: declare `api_version`, `name`, `discover_cases()`, `execute_step()`, and `evaluate()`; override optional hooks such as `setup_env()`, `verify_env()`, `teardown()`, `create_reporter()`, `create_runner()`, `register_cli()`, and remediation hooks as needed.
 
-For a complete, runnable reference (installable + discoverable via
-`testpilot.plugins`), see `examples/sample_echo/` and its README.
+Plugins import the public SDK surface from `testpilot.api`; they must not reach into `testpilot.core`, `testpilot.schema`, `testpilot.reporting`, `testpilot.transport`, or `testpilot.runtime` internals. See `plugins/_template/README.md` and `docs/plugin-dev-guide.md` for the current contract.
+
+For a complete runnable zero-hardware reference, see `examples/sample_echo/`.
 
 ### Project Structure
 
@@ -367,72 +336,89 @@ src/testpilot/
   runtime/    # run backend
 plugins/
   _template/  # plugin SDK scaffold (not discoverable on its own)
-configs/      # operator-local effective testbed.yaml (auto-staged by CLI; git-ignored)
-docs/         # plan, todos, phase docs
-scripts/      # utility scripts (install, policy_cli_help, gen_cases)
+examples/
+  sample_echo/ # runnable public reference plugin
+configs/      # effective runtime testbed.yaml for the selected core path
+docs/         # current docs plus historical plans/specs
+scripts/      # install/release/support utilities
 skills/       # repository agent skills
 tests/        # core test suite
 ```
 
 ### Versioning and Release
 
-The canonical project version lives in `VERSION`; `pyproject.toml` and
-`src/testpilot/__init__.py` mirror it and must stay identical. Release tags use
-Semantic Versioning `vX.Y.Z`. User-facing pull requests should update
-`CHANGELOG.md` under `Unreleased`, or explicitly record why no changelog entry
-is needed. `testpilot --version` prints this core version followed by every
-installed plugin distribution version and declared SDK API version; a broken
-plugin metadata record is shown as `unknown` without hiding the remaining
-inventory.
+The canonical project version lives in `VERSION`; `pyproject.toml` uses that dynamic version and `src/testpilot/__init__.py` mirrors it. Release tags use Semantic Versioning `vX.Y.Z`.
+
+User-facing pull requests should carry a changelog fragment or explicitly record why no changelog entry is needed. `testpilot --version` prints the core version followed by every installed plugin distribution version and declared SDK API version; a broken plugin metadata record is shown as `unknown` without hiding the remaining inventory.
 
 ---
 
 ## 繁體中文
 
-針對嵌入式裝置驗證（prplOS / OpenWrt）的 plugin 化測試自動化框架。
+**TestPilot Core 是一套 Plugin 化的測試自動化與驗證框架。**
 
-本 repo 是 **TestPilot core**：deterministic verdict kernel、plugin SDK
-（`testpilot.api`）、CLI host、transport、schema 與 reporting。它內含
-`plugins/_template/` plugin 骨架，但不含任何具體測試 plugin。真正的 plugin
-（例如 `wifi_llapi`、`brcm_fw_upgrade`）各自存在於獨立 repo，透過
-`testpilot.plugins` entry-point group 自我註冊。
+Core 提供具版本的 Plugin SDK（`testpilot.api`）、CLI host、測試生命週期編排、evidence / trace 蒐集、reporting contract、transport / run-backend abstraction，以及選配的 Agent-assisted control plane。各專案真正要測什麼、如何操作環境、如何判讀 domain-specific 條件，則由各自的 Plugin 實作。
 
-### 概觀
+### 定位與目前適用範圍
 
-TestPilot 是針對 prplOS / OpenWrt 嵌入式裝置的 plugin 化測試自動化框架，架構分為兩個平面：
+TestPilot Core 的 Plugin extension model 沒有綁死單一產品領域，但這個專案的來源與目前主要實績仍是 embedded / real-hardware verification。現有 field usage、內建 transport、managed-install profile 與大部分複雜案例，也仍集中在設備測試。
 
-- **Deterministic verdict kernel** — 測試執行、證據蒐集、pass/fail 判定與報表投影。
-- **Copilot SDK control plane** — per-case session foundation、lifecycle hooks、advisory audit、分層環境修復，以及 custom agents / skills / 選擇性 MCP 等擴充面。
+因此目前比較準確的說法是：
 
-核心原則：**Copilot SDK 負責 control plane；它不決定最終 verdict。**
+- TestPilot Core **不是嵌入式專用**；專案可以透過公開 SDK 自行提供 Plugin、cases、環境操作、runner、reporter 與整合方式。
+- TestPilot Core 也**沒有宣稱任意 domain 開箱即用**。在目前已實際驗證的 device / real-hardware workflow 之外，採用者需要自行開發並驗證對應的 Plugin integration。
 
-tier-1 先執行 plugin 的 deterministic allowlist 修復；只有達到設定的連續失敗門檻，
-才會在 retry 間隙 opt-in 升級 tier-2。core 以 plugin 宣告的 environment capability
-catalog 建立 bounded、tool-denied one-shot prompt，plugin 執行通過 schema/budget 的
-plan 後，core 一律強制重跑 deterministic `verify_env`。agent 不具 verdict 權限，也
-不能改 case semantics。任何介入都以 `agent_recovered` 標記並寫入已去敏、有上限的
-case/run audit；該標記只代表 agent 曾介入，不代表 verify gate 已通過。詳見
-[Tier-2 Environment Recovery Design](docs/superpowers/specs/2026-07-17-tier2-env-recovery-design.md)。
+Core wheel 本身不包含 domain test suite。目前公開 reference 包含：
+
+- `examples/sample_echo/`：不需要硬體的 runnable SDK example，用來示範 package、discovery、execution、verdict 與 plugin-owned CLI。
+- [`serialwrap_reliability`](https://github.com/hamanpaul/serialwrap/tree/main/reliability)：位於公開 `serialwrap` repo 的實機 TestPilot integration，用於 serialwrap reliability workflow；它與 Core 分開維護。
+
+### 架構
+
+預設的 core-owned execution path 可以拆成兩個主要 concern：
+
+- **Deterministic verdict kernel** — 執行 lifecycle、蒐集 evidence、管理 retry / timeout、產生 canonical trace/result 並交給 reporter；真正的 domain-specific Pass / Fail 語意仍由 Plugin 的 `evaluate()` 定義。
+- **Copilot SDK control plane** — per-case session foundation、lifecycle hooks、advisory planning、分層 environment recovery，以及 custom agents / skills / selective MCP 等 extension surface。
+
+核心原則：**Agent 可以協助，但不擁有最終 verdict。**
+
+目前已落地的 control-plane 子集：
+
+- per-case runner selection 與 `selection_trace`
+- best-effort per-case Copilot session foundation
+- lifecycle hooks：`pre_case` / `post_case` / `pre_step` / `post_step` / `on_failure` / `on_retry`
+- advisory collection，以及 retry 間的 tier-1 deterministic remediation / opt-in tier-2 one-shot planning
+
+tier-2 只有在設定的 tier-1 連續失敗門檻後才會進入。Core 依 Plugin 宣告的 environment capabilities 建立 bounded、tool-denied one-shot prompt；Plugin 執行經 schema / budget 驗證的 plan 後，Core 仍強制執行 deterministic `verify_env`。Agent 不具有改寫 case semantics 或 canonical verdict 的權限。`agent_recovered` 只表示 Agent 曾介入，不代表 verification gate 已經通過；介入紀錄會保存在有長度上限且經過去敏的 case / run audit artifacts。
+
+> Plugin 也可以提供 custom runner。這是刻意保留的 extension path；custom runner 會自行承擔更多 execution pipeline 責任，也不會自動取得所有 core-owned analysis path。因此文件會區分預設的 **core-owned execution path** 與 plugin-owned custom execution。
 
 ### 前置需求
 
+Core / SDK 開發：
+
 - **Python 3.11+**
 - **git**
-- **[uv](https://docs.astral.sh/uv/)** — 安裝器優先採用的 Python 套件管理器
-- **[serialwrap](https://github.com/hamanpaul/serialwrap)** — DUT / STA 通訊用的 UART serial multiplexer；managed install 會自動安裝/更新
+- **[uv](https://docs.astral.sh/uv/)** — 本 repo 建議使用的 Python package manager
 
-手動管理 serialwrap 的開發者 checkout 可用環境變數指定路徑：
+其他依賴由 Plugin / workflow 決定。特別是 [`serialwrap`](https://github.com/hamanpaul/serialwrap) 是目前 UART / device workflow 的必要元件，現行 managed-install profile 也會 pin 並安裝它；但它不是所有 TestPilot Plugin 的概念性必要條件。`sample_echo` 不需要硬體即可執行。
+
+需要 serialwrap 的開發者 checkout，可用環境變數指定 binary：
 
 ```bash
 export SERIALWRAP_BIN=/path/to/serialwrap
 ```
 
-> 解析順序：`SERIALWRAP_BIN` 環境變數 → `testbed.yaml` 設定 → 失敗結束。
+或在 `configs/testbed.yaml` 指定：
+
+```yaml
+testbed:
+  serialwrap_binary: /path/to/serialwrap
+```
 
 ### 快速開始
 
-**線上一鍵安裝**（需要 fine-grained read-only PAT，具備 `hamanpaul/testpilot-core`
-及所有 plugin repo 的 `contents: read` 權限）：
+目前 repository 內的 managed installer 是依維護者現行 QC / TEST deployment profile 設計，會解析 `install-manifest.yaml` 中宣告的 Core 與 Plugin repositories；若 manifest 包含非公開 Plugin，便需要相應的 repository 權限。
 
 ```bash
 TESTPILOT_INSTALL_TOKEN=<fine-grained read-only PAT> bash scripts/install.sh
@@ -440,13 +426,20 @@ testpilot --verify-install
 testpilot list-plugins
 ```
 
-透過 `--plugins` 只安裝部分 plugin：
+只安裝 manifest 中指定的 Plugin：
 
 ```bash
-TESTPILOT_INSTALL_TOKEN=<PAT> bash scripts/install.sh --plugins wifi_llapi
+TESTPILOT_INSTALL_TOKEN=<PAT> bash scripts/install.sh --plugins <plugin_name>
 ```
 
-安裝後，列出並執行 plugin：
+若是外部 Plugin 開發，通常可以直接準備 TestPilot Core 的開發環境，再選擇正常安裝 Plugin package，或直接用 path mode 跑尚未安裝的 Plugin checkout：
+
+```bash
+testpilot /path/to/my_plugin --help
+testpilot /path/to/my_plugin
+```
+
+安裝後可使用：
 
 ```bash
 testpilot list-plugins
@@ -454,9 +447,11 @@ testpilot list-cases <plugin>
 testpilot run <plugin>
 ```
 
+> 經 generic core path 解析 Plugin context 時，CLI 目前會把該 Plugin 的 `testbed.yaml.example` stage 到 `configs/testbed.yaml`；切換 Plugin 時會覆寫 effective file。不要把 staged file 當成永久設定來源，專案需要保存的環境設定應留在自己的 Plugin 專案中。
+
 ### Managed Install 與 Update
 
-支援的 QC/TEST 安裝採用 managed venv 加 pinned wheels（不再使用 git checkout）：
+目前支援的 QC / TEST 安裝使用 managed venv。Online install 會解析**最新且 SDK API 相容**的 Core 與 manifest Plugin release；`serialwrap` 則仍由 `install-manifest.yaml` 明確 pin。Offline bundle 是一份 SHA256 驗證過的精確 snapshot。
 
 ```bash
 ~/.local/share/testpilot/.venv   # managed runtime virtualenv
@@ -464,43 +459,32 @@ testpilot run <plugin>
 ~/.agents/skills/testpilot-normal-test
 ```
 
-**線上安裝**：
+**線上安裝：**
 
 ```bash
 TESTPILOT_INSTALL_TOKEN=<fine-grained read-only PAT> bash scripts/install.sh
 ```
 
-**離線安裝**（先在有網路的 Linux 機器以 `scripts/build-bundle.sh` 建置 bundle，
-再傳至目標機器）：
+**離線安裝：**
 
 ```bash
-# 有網路機器上建置：
+# 有網路的 Linux 主機：
 bash scripts/build-bundle.sh
 
-# 離線機器上安裝（驗證 SHA256SUMS，以 --no-index 安裝）：
+# 目標主機（驗證 SHA256SUMS、--no-index）：
 bash scripts/install.sh --offline testpilot-bundle-<ver>-linux-<arch>-cp<XY>.tar.gz
 ```
 
 **更新與驗證：**
 
 ```bash
-testpilot --update            # 重解析 manifest、重裝 pinned wheels、同步 plugin
-testpilot --verify-install    # 回報安裝狀態
+testpilot --update
+testpilot --verify-install
 ```
 
-`--update` 會先快照環境；若更新後 verify 失敗，rollback **只走離線**
-（以 `pip install --no-index --find-links` 對安裝器保存在
-`${TESTPILOT_HOME:-~/.local/share/testpilot}/.wheel-cache` 的本地 wheel cache 重裝），
-絕不連到 public index。若 cache 內 wheel 不足，rollback 會明確失敗並提示改用
-`install.sh --offline` 從已知良好的 bundle 重裝。
+`--update` 會先快照目前環境。若 post-update verification 失敗，rollback 只使用 `${TESTPILOT_HOME:-~/.local/share/testpilot}/.wheel-cache` 的本地 wheel cache，不會退回 public package index；cache 不足時會明確失敗並要求用已知良好的 offline bundle 重裝。
 
-### CLI 進入點
-
-正常操作使用已安裝的 `testpilot` 指令；開發者 checkout 在除錯 repo 時仍可使用
-`python -m testpilot.cli`。Plugin 專屬的 CLI 指令是在 import `testpilot.cli`
-時由已安裝的 plugin 套件註冊。`--root <path>` 只選擇 runtime project root
-（cases/configs/reports），不會用 `<path>/plugins` 的指令動態替換已註冊的
-plugin CLI 介面。
+### CLI 與 Plugin 選取
 
 核心 host 指令：
 
@@ -511,41 +495,24 @@ testpilot list-cases <plugin>
 testpilot run <plugin>
 ```
 
-選擇 plugin 有兩種形式：
+Plugin 可用兩種形式選取：
 
 | 形式 | 解析方式 | 使用時機 |
 | --- | --- | --- |
-| `testpilot <PLUGIN_NAME> [ARGS]...` | registry mode——目前環境已安裝的 `testpilot.plugins` entry point | plugin 已安裝 |
-| `testpilot <PLUGIN_PATH> [ARGS]...` | path mode——磁碟上的 plugin 專案目錄 | 要跑尚未（或不打算）安裝的 checkout |
+| `testpilot <PLUGIN_NAME> [ARGS]...` | registry mode——目前環境已安裝的 `testpilot.plugins` entry point | Plugin 已安裝 |
+| `testpilot <PLUGIN_PATH> [ARGS]...` | path mode——磁碟上的 Plugin project root | 要跑尚未安裝的 checkout |
 
 ```bash
-testpilot <plugin> --case D001            # registry mode
-testpilot /path/to/my_plugin --case D001  # path mode，同一個 plugin 指令
-testpilot ../my_plugin                    # 相對路徑同樣可用
+testpilot <plugin> --case D001
+testpilot /path/to/my_plugin --case D001
+testpilot ../my_plugin
 ```
 
-兩種形式都 dispatch 到同一個 plugin 自有指令，因此 plugin 專屬選項行為完全一致。
-path mode 細節：
-
-- `PLUGIN_PATH` 指的是**專案根目錄**——含 `pyproject.toml` 且宣告
-  `[project.entry-points."testpilot.plugins"]` 的那一層。該表是 plugin 名稱與
-  import 目標的唯一真實來源，因此兩種模式對「這是哪個 plugin」的認定一致。
-- 專案必須剛好宣告一個 plugin。宣告多個時直接拒絕而不猜測，請改為安裝後以名稱選取。
-- 專案內那份優先於同名的已安裝套件，**即使該套件已經被 import 過**。若宣告的模組
-  最終仍解析到專案之外，會直接拒絕執行，而不是靜默測到錯的那棵樹。
-- path mode 不會繞過 SDK API 版本閘：不相容的 plugin 與 registry mode 一樣被拒絕。
-- 已註冊的 plugin 名稱永遠優先於工作目錄下的同名資料夾，因此 path mode 不可能遮蔽
-  已安裝的 plugin。
-- 判定為路徑的條件：含路徑分隔符、以 `.` 或 `~` 開頭、或該名稱確實是一個既有目錄。
-  其餘一律視為 plugin 名稱或子命令。
+兩種形式都 dispatch 到同一個 Plugin-owned command。Path mode 仍使用專案自己的 `[project.entry-points."testpilot.plugins"]` 作為 identity authority，也不會繞過 SDK API compatibility gate；若同名 installed package 已載入，Core 會確認實際 import 的 code 仍位於指定 project 之下，否則拒絕執行。
 
 ### Azure OpenAI（BYOK）
 
-當 Azure endpoint、API key 與 deployment 都存在時，TestPilot core 自動啟用
-Azure；沒有 key 時使用 deterministic/no-agent mode，缺少其他欄位只會產生
-非阻斷的 misconfigured notice；若 `COPILOT_PROVIDER_TYPE` 被設成非 `azure`
-值，也會被視為 misconfigured。`COPILOT_PROVIDER_TYPE` 不作為啟用開關，core
-只建立 Azure provider。
+當 Azure endpoint、API key 與 deployment 都存在時，TestPilot Core 自動啟用 Azure；沒有 key 時使用 deterministic/no-agent mode。部分設定缺漏或 `COPILOT_PROVIDER_TYPE` 為非 `azure` 值時，會回報去敏的 misconfigured notice，並繼續 deterministic execution。
 
 ```bash
 export COPILOT_PROVIDER_BASE_URL=https://your-resource.openai.azure.com
@@ -555,42 +522,23 @@ export COPILOT_PROVIDER_AZURE_API_VERSION=2024-10-21
 testpilot run <plugin_name>
 ```
 
-每案 planning 僅供 advisory；tier-2 需 plugin opt-in，deterministic
-remediation 仍由 plugin 負責。core 報表位於 `artifact_dir/agent_usage`，共享
-run-end analysis token 不分攤到個案；custom/skeleton path 回報
-`unsupported_execution_path` 且不呼叫 core model。效益指標為 observational，
-不宣稱因果 uplift/regression。
+Per-case planning 僅供 advisory；tier-2 需要 Plugin opt-in，deterministic remediation 仍由 Plugin 負責。Core-owned usage / observational metrics 會寫入 `artifact_dir/agent_usage`；custom / skeleton execution path 不呼叫 core model，並回報 `unsupported_execution_path`。
 
 ### 撰寫 Plugin
 
-複製 SDK 骨架並從你的 plugin 套件註冊：
-
-```bash
-cp -r plugins/_template plugins/my_plugin
-```
+Plugin 從 `testpilot.api` 使用公開 SDK，而不是依賴 Core 私有模組：
 
 ```toml
 [project.entry-points."testpilot.plugins"]
-my_plugin = "plugins.my_plugin.plugin:Plugin"
+my_plugin = "my_plugin.plugin:Plugin"
 ```
 
-```bash
-uv pip install -e .
-testpilot list-plugins
-```
+必要 contract 包含 `api_version`、`name`、`discover_cases()`、`execute_step()`、`evaluate()`；依需求可覆寫 `setup_env()`、`verify_env()`、`teardown()`、`create_reporter()`、`create_runner()`、`register_cli()` 與 remediation hooks。
 
-實作 `PluginBase` 契約（宣告 `api_version`、`name`、`discover_cases()`、
-`execute_step()`、`evaluate()`；視需要覆寫 `setup_env()`、`verify_env()`、
-`teardown()`、`create_reporter()`、`create_runner()`、`register_cli()` 等選用
-hook）。Plugin 從 `testpilot.api` 匯入公開 SDK 介面，不得直接 reach 進
-`testpilot.core` / `schema` / `reporting` / `transport` / `runtime` 內部。完整
-契約與選用 hook 對照表見 `plugins/_template/README.md`。
+完整 contract 請見 `plugins/_template/README.md` 與 `docs/plugin-dev-guide.md`；零硬體 runnable example 請見 `examples/sample_echo/`。
 
 ### 版本與發布
 
-canonical 版本位於 `VERSION`；`pyproject.toml` 與
-`src/testpilot/__init__.py` 為鏡像，必須一致。release tag 採 Semantic
-Versioning `vX.Y.Z`。對外 PR 應更新 `CHANGELOG.md` 的 `Unreleased`，或明確記錄
-為何不需 changelog entry。`testpilot --version` 會在 core 版本後列出所有已安裝
-plugin 的 distribution version 與宣告的 SDK API version；單一 plugin metadata
-損壞時以 `unknown` 顯示，不會阻斷其餘 inventory。
+Canonical project version 位於 `VERSION`；`pyproject.toml` 使用該 dynamic version，`src/testpilot/__init__.py` 維持鏡像。Release tag 採 Semantic Versioning `vX.Y.Z`。
+
+對外可見的變更應帶 changelog fragment，或在 PR 中明確說明為何不需要。`testpilot --version` 會在 Core 版本後列出已安裝 Plugin 的 distribution version 與 SDK API version；單一 Plugin metadata 損壞時以 `unknown` 顯示，不阻斷其餘 inventory。

--- a/changelog.d/framework-positioning.md
+++ b/changelog.d/framework-positioning.md
@@ -1,0 +1,6 @@
+---
+type: change
+scope: docs
+---
+
+- 調整 TestPilot Core 的公開定位與說明：README、package metadata、CLI help 與 SDK docstring 改以「plugin-based test automation and verification framework」描述，不再把 Core 限定為 embedded-only；同時明確保留目前主要實績仍集中於 embedded / real-hardware verification、非任意 domain 開箱即用的限制。並同步修正 release-flow 中已過時的 static-version / metadata-only release 敘述，使其對齊現行 dynamic version、GitHub Release wheel 與 managed-install 行為。

--- a/docs/release-flow.md
+++ b/docs/release-flow.md
@@ -1,133 +1,90 @@
 # TestPilot Versioning and Release Flow
 
-This document defines the repository-level versioning and release process for
-TestPilot starting from the managed install baseline `v0.2.0`.
+This document defines the repository-level versioning and release process for TestPilot Core. It describes the current wheel-based GitHub Release flow and the managed QC/TEST installation model.
 
 ## 1. Versioning policy
 
 TestPilot uses Semantic Versioning with git tags in the form `vX.Y.Z`.
 
-- **Major (`X`)**: breaking operator-facing or consumer-facing changes
-  (CLI contract breaks, artifact layout breaks, report format removals, or
-  incompatible workflow changes).
-- **Minor (`Y`)**: backward-compatible features (new commands, new reporting
-  capabilities, new plugin/runtime features, new supported workflows).
-- **Patch (`Z`)**: backward-compatible fixes, documentation corrections, test
-  improvements, and release automation maintenance.
+- **Major (`X`)**: breaking operator-facing or plugin-SDK changes.
+- **Minor (`Y`)**: backward-compatible features such as new commands, SDK additions, reporting capabilities, runtime features, or supported workflows.
+- **Patch (`Z`)**: backward-compatible fixes, documentation corrections, test improvements, and release automation maintenance.
 
-`v0.2.0` is the starting baseline for the managed installer/update flow.
+The plugin SDK contract has its own `testpilot.api.API_VERSION` (`major.minor`) and is intentionally separate from the package release version. A package patch/minor release does not necessarily imply an SDK API change.
 
 ## 2. Canonical version sources
 
-- **Canonical source**: `VERSION`
-- **Packaging mirror**: `pyproject.toml` → `[project].version`
+- **Canonical project version**: `VERSION`
+- **Packaging version**: `pyproject.toml` uses Hatch dynamic versioning sourced from `VERSION`
 - **Runtime mirror**: `src/testpilot/__init__.py` → `__version__`
 - **Published identifier**: git tag `vX.Y.Z`
 
-All four must agree for a release. The repo test suite and release workflow
-validate that `VERSION`, `pyproject.toml`, `src/testpilot/__init__.py`, and the
-pushed tag stay in sync.
+`VERSION`, the runtime mirror, package metadata produced from `pyproject.toml`, and the release tag must agree. Repository tests and the release workflow validate this contract.
 
 ## 3. Day-to-day pull request expectations
 
-Normal feature/fix branches continue to merge through GitHub pull requests.
+Normal feature/fix branches merge through GitHub pull requests.
 
-Each PR should use the GitHub PR template and explicitly cover:
+Each PR should explicitly cover:
 
-- whether `CHANGELOG.md` needs an `Unreleased` entry
+- whether a `changelog.d/*.md` fragment is required
 - whether README / docs / AGENTS updates are required
-- whether README CLI help marker blocks governed by `.project-policy.yml` need
-  synchronization
+- whether README CLI help marker blocks governed by `.project-policy.yml` need synchronization
 - what validation was run
 - whether the change has release-note impact
 
 Rule of thumb:
 
-- **User-facing or operator-facing changes**: update `CHANGELOG.md`
-- **Purely internal churn with no release-note value**: explain why changelog is
-  not needed in the PR
+- **User-facing or operator-facing changes**: add a changelog fragment.
+- **Purely internal churn with no release-note value**: explain in the PR why a fragment is not needed.
+
+Do not edit a future dated release section directly during ordinary development. Pending release notes live in `changelog.d/` until release preparation collates them.
 
 ## 4. Release preparation flow
 
 Prepare releases in a dedicated branch and PR:
 
-1. Branch from `main` as `feature/<slug>` (for example
-   `feature/release-vX-Y-Z`; R-12 branch slugs allow only `[a-z0-9-]`, so drop
-   the dots from the version).
-2. Update `VERSION`, `pyproject.toml`, and `src/testpilot/__init__.py` to
-   `X.Y.Z`.
-3. Finalize `CHANGELOG.md` by collating pending fragments into the release
-   section (policy v1.0.9+ uses the per-PR `changelog.d/*.md` fragment model,
-   not direct `Unreleased` edits):
-   - `python3 -m policy_check.changelog collate --version X.Y.Z --date YYYY-MM-DD`
-     folds every `changelog.d/*.md` fragment into a dated `## [X.Y.Z]` section
-     (grouped by fragment `type`: `feat`→Added, `fix`→Fixed,
-     `refactor`/`perf`/`change`→Changed, `remove`→Removed,
-     `deprecate`→Deprecated, `security`→Security — `chore` is not a valid
-     fragment type, use `change`) and clears `changelog.d/`.
-   - keep a fresh, empty `## [Unreleased]` section at the top for readability
-     (R-04 at v1.0.9+ only requires the `# Changelog` title, not populated
-     `Unreleased` content).
-   - if `[Unreleased]` still carries stale direct-edit entries left over from
-     before the fragment switch, fold anything not already covered by a
-     fragment into the new dated section, then clear `[Unreleased]`.
-4. Update `README.md`, `docs/release-flow.md`, and `AGENTS.md` if the release
-   changes supported workflows, release rules, or operator guidance.
-5. Ensure CI, release version validation, and policy/help sync checks are green.
-6. Merge the release PR into `main`.
+1. Branch from `main` as `feature/<slug>` (for example `feature/release-v0-3-8`; R-12 branch slugs allow only `[a-z0-9-]`).
+2. Update `VERSION` and `src/testpilot/__init__.py` to `X.Y.Z`. `pyproject.toml` remains dynamically sourced from `VERSION`; there is no static `[project].version` field to edit.
+3. Finalize `CHANGELOG.md` by collating pending fragments:
 
-Recommended PR title (must satisfy R-10 conventional-commit; `release:` is not a
-valid type):
+   ```bash
+   python3 -m policy_check.changelog collate --version X.Y.Z --date YYYY-MM-DD
+   ```
 
-- `chore(release): prepare vX.Y.Z`
+   The collator folds `changelog.d/*.md` into a dated `## [X.Y.Z]` section and clears the fragment directory. Supported fragment groups include `feat`, `fix`, `refactor`, `perf`, `change`, `remove`, `deprecate`, and `security`; `chore` is not a valid fragment type, so use `change` for maintenance entries that belong in release notes.
+4. Keep a fresh empty `## [Unreleased]` section at the top of `CHANGELOG.md` for readability.
+5. Update README / docs / AGENTS if supported workflows, operator guidance, SDK behavior, or release rules changed.
+6. Run the repository test suite and policy/preflight checks.
+7. Open the release PR with the `release:vX.Y.Z` label. Use `skip-changelog` on the release-prep PR because the pending fragments have already been moved into the dated release section.
+8. Merge the release PR into `main`.
 
-Apply a `release:vX.Y.Z` label to the PR so the deferred VERSION bump (VERSION
-leads the latest tag during release prep) is accepted by R-07.
+Recommended PR title:
 
-Also apply the `skip-changelog` label: release prep empties the `Unreleased`
-queue into `## [X.Y.Z]`, so R-09 (which expects an `Unreleased` bullet when code
-files change) would otherwise fail even though the changes are recorded under
-`## [X.Y.Z]`.
+```text
+chore(release): prepare vX.Y.Z
+```
 
 ## 5. Tagging and publication
 
 After the release PR is merged:
 
-1. Create git tag `vX.Y.Z` on the merged `main` commit.
-2. Push the tag (or create it from GitHub on the target commit).
-3. The tag push triggers `.github/workflows/release.yml`.
-4. The workflow:
-    - verifies tag/version consistency
-    - runs the pinned project policy check
-    - runs release governance tests and the full repository test suite
-    - creates the GitHub Release
-    - uses GitHub auto-generated release notes for the published release page
+1. Create tag `vX.Y.Z` on the merged `main` commit.
+2. Push the tag.
+3. `.github/workflows/release.yml` runs the project policy gate and release validation.
+4. The release job verifies tag/version consistency, runs tests, builds the wheel, creates the GitHub Release, and uploads the wheel asset.
 
-GitHub Releases are the canonical published release notes surface. `CHANGELOG.md`
-remains the curated in-repo history.
+GitHub Releases are the canonical published release surface. `CHANGELOG.md` remains the curated in-repository history.
 
-### Current deployment model
+### Current published artifact
 
-The current release workflow publishes **metadata only**:
+The release workflow publishes a Python wheel for `testpilot-core` to the corresponding GitHub Release. It does not currently publish TestPilot Core to a public Python package index.
 
-- git tag `vX.Y.Z`
-- GitHub Release page with generated release notes
+The repository also contains a managed installer used by the maintainer's current QC/TEST deployment profile. That installer resolves the core and the plugin repositories listed in `install-manifest.yaml`; it may therefore require credentials for non-public plugin repositories declared by that manifest.
 
-It does **not** build or upload wheel / sdist / binary assets yet. QC/TEST
-operators should install through the managed installer, which resolves
-`latest-release` to the newest stable `vX.Y.Z` tag by default:
+The current managed online flow resolves the newest release compatible with the declared SDK contract where applicable. `serialwrap` is separately pinned because it does not use the TestPilot plugin SDK compatibility contract.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/paulc-arc/testpilot/main/scripts/install.sh | bash
-testpilot --verify-install
-```
-
-For local validation or controlled rollouts, override the managed source/ref:
-
-```bash
-TESTPILOT_REPO_URL=https://github.com/hamanpaul/testpilot.git TESTPILOT_REF=vX.Y.Z bash scripts/install.sh
-testpilot --update vX.Y.Z
-```
+`testpilot --update REF` currently accepts a `REF` argument for interface compatibility, but cross-version targeting is not implemented; the command reinstalls/reconciles the currently resolved manifest-managed set. Do not document it as a working way to select an arbitrary historical release.
 
 ## 6. Release gates
 
@@ -135,34 +92,48 @@ Do not tag a release until all of the following are true:
 
 - the release PR is merged into `main`
 - GitHub Actions CI is green for the release commit
-- `VERSION`, `pyproject.toml`, `src/testpilot/__init__.py`, and the intended
-  tag match
+- `VERSION`, runtime `__version__`, built package metadata, and intended tag agree
 - `CHANGELOG.md` is finalized
 - README / docs / AGENTS updates are merged when user-facing behavior changed
-- `.project-policy.yml` still declares the required CLI help sync marker blocks
+- README CLI help marker blocks are synchronized when CLI help changed
+- the manifest API-compatibility gate passes
+- the offline installer integration gate passes in CI
 
-The minimum automated CI gate is the repo test suite (`uv run pytest -q`) plus
-the release governance tests that validate policy config and release metadata.
+The repository CI currently includes the core test suite, a real install/discovery/run smoke for `examples/sample_echo`, release-governance tests, manifest SDK compatibility checks, and an offline installer integration smoke.
 
-## 7. Hotfixes
+## 7. Managed-install validation
+
+For a managed installation, use:
+
+```bash
+testpilot --verify-install
+```
+
+The managed installer and `--update` path are separate from ordinary plugin development. Plugin developers can use the core package with an independently installed plugin, or use path mode to run a plugin checkout directly:
+
+```bash
+testpilot /path/to/my_plugin --help
+testpilot /path/to/my_plugin
+```
+
+## 8. Hotfixes
 
 Hotfix releases follow the same flow with a patch bump:
 
 1. branch from `main`
-2. fix the issue
-3. prepare the next patch release PR on a `feature/<slug>` branch (for example
-   `feature/release-v0-2-1`)
-4. merge
-5. tag the merged commit
+2. fix the issue and add an appropriate changelog fragment
+3. merge the fix PR
+4. prepare the next patch release PR
+5. merge the release PR
+6. tag the merged release commit
 
-## 8. Recovery when a tag is wrong
+## 9. Recovery when a tag is wrong
 
-If a tag is pushed with the wrong version:
+If a tag is pushed with the wrong version or wrong commit:
 
-1. delete the incorrect GitHub Release (if it was created)
+1. delete the incorrect GitHub Release if it was created
 2. delete the incorrect git tag
 3. fix version metadata / changelog on a new PR
-4. retag the correct merged `main` commit
+4. tag the correct merged `main` commit
 
-Do not reuse an incorrect tag name for a different commit without first
-cleaning up the bad release/tag state.
+Do not reuse an incorrect tag name for a different commit until the bad release/tag has been removed and the intended target has been verified.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,19 +1,21 @@
 # TestPilot 系統規格書
 
-> 版本：v0.1.0-draft（第三次重構規劃基線）
-> 更新日期：2026-07-17
+> 狀態：第三次重構設計基線；現行對外定位與安裝方式以 `README.md` 為準
+> 更新日期：2026-08-11
 > 深度參考已收斂回本文件；詳細研究筆記改為 local-only，不再納入 repo。
 
 ---
 
 ## 1. 系統概述
 
-TestPilot 是一套 plugin-based 嵌入式裝置測試自動化框架，面向 prplOS / OpenWrt 裝置。第三次重構後的系統設計以兩個平面為核心：
+TestPilot Core 是一套 plugin-based test automation and verification framework。公開 SDK 與 Plugin contract 不把 Core 綁定到單一產品 domain；但目前最完整的 field usage、transport integration 與複雜驗證案例仍集中在 prplOS / OpenWrt 等 embedded / real-hardware 場景。因此本文件中的 DUT / STA / Wi-Fi 範例應視為目前主要 reference path，而不是 TestPilot Core 對所有 Plugin 的 domain 限制。
 
-1. **Deterministic verdict kernel**：負責正式測試執行、證據蒐集、pass/fail 判定與報表投影。
+第三次重構後的系統設計以兩個平面為核心：
+
+1. **Deterministic verdict kernel**：負責正式測試生命週期、證據蒐集、retry/timeout、canonical trace/result 與報表投影；domain-specific pass/fail semantics 由 plugin 的 `evaluate()` 定義。
 2. **Copilot SDK control plane**：負責 per-case session foundation、lifecycle hooks、advisory/remediation，以及 `custom_agents`、`skills`、`selective MCP` 等 extension surfaces，並提供操作員導向的自然語言 UX。
 
-`wifi_llapi` 仍是目前最完整的落地路徑；第三次重構的重點不是把 YAML 變成 prompt，也不是把最終 verdict 交給 agent，而是把既有 deterministic hot path 保留下來，再讓 Copilot SDK 吃掉 agent orchestration 的複雜度。core 現已提供 tier-1 deterministic-first、連敗後 opt-in tier-2 one-shot 的 domain-agnostic framework；tier-2 只能規劃 plugin-advertised environment capabilities，plugin 執行後仍由 core 強制 deterministic `verify_env`，且不允許 agent 改 testcase semantics、step 指令、pass criteria 或 verdict。實體 plugin 必須另行實作並啟用 execution plane。
+`wifi_llapi` 是形成第三次重構需求時最完整的 field path，因此本規格仍保留其案例作為設計背景。重構的重點不是把 YAML 變成 prompt，也不是把最終 verdict 交給 agent，而是保留 deterministic hot path，再把 agent orchestration 隔離到 control plane。core 現已提供 tier-1 deterministic-first、連敗後 opt-in tier-2 one-shot 的通用 recovery contract；tier-2 只能規劃 plugin-advertised environment capabilities，plugin 執行後仍由 core 強制 deterministic `verify_env`，且不允許 agent 改 testcase semantics、step 指令、pass criteria 或 canonical verdict。實際 domain capability 與 executor 必須由各 plugin 自行實作並驗證。
 
 目前已落地的 control-plane 子集：
 
@@ -23,6 +25,8 @@ TestPilot 是一套 plugin-based 嵌入式裝置測試自動化框架，面向 p
 - advisory collection，以及 retry 間的 tier-1 deterministic / opt-in tier-2 environment recovery
 
 `custom_agents`、`skills`、`mcp_servers` 等欄位已存在於 request / 規格層，但目前 orchestrator 建 session 時尚未預設自動接線，因此這些部分仍屬 extension surface，而不是完整 current-state hot path。
+
+Plugin 亦可提供 custom runner。Custom runner 是正式 extension path，但會自行承擔較多 execution pipeline 責任，也不會自動取得所有 core-owned analysis / cost-reporting path；因此本文所稱 deterministic kernel 預設指 **core-owned execution path**。
 
 ### Azure-only core cost reporting
 
@@ -46,6 +50,7 @@ zero core calls.
 ### 核心設計原則
 
 - **Kernel 與 Control Plane 分層**：Copilot SDK 處理 agent/control-plane；`plugin.evaluate()` 與正式 rerun 結果仍是最終 verdict 來源。
+- **Plugin 擁有 domain semantics**：Core 定義 lifecycle / SDK / trace contract；case meaning、environment action、pass criteria 與 domain-specific reporter 由 Plugin 提供。
 - **YAML 是 executable spec，不是主要 prompt**：formal case semantics 應由 schema、plugin hook、transport 決定。
 - **Structured evidence 是唯一真相來源**：selection trace、attempt trace、commands、outputs、canonical result 需可追蹤。
 - **報告投影分離**：`xlsx` 只保留對外交付的 `Pass/Fail`；`md/json` 承載 richer diagnostic statuses、root cause、suggestion、remediation history。
@@ -54,6 +59,8 @@ zero core calls.
 ---
 
 ## 2. 目標架構圖
+
+下圖保留目前主要 device-oriented reference path 的 transport 範例；Plugin 可透過公開 SDK 提供其他 domain 所需的 environment / execution integration。
 
 ```mermaid
 graph TB
@@ -74,9 +81,9 @@ graph TB
         cfg["TestbedConfig + CaseSchema"]
         plugin["Plugin hooks\nsetup_env / verify_env\nexecute_step / evaluate / teardown"]
         yaml["YAML Cases"]
-        transport["Transport\nserialwrap / adb / ssh / network"]
+        transport["Transport / RunBackend\nserialwrap / ssh / custom integration"]
         evidence["Structured Evidence\nselection trace / attempts / canonical result"]
-        report["Report Projection\nxlsx / md / json\nhtml (opt-in from json)"]
+        report["Report Projection\nxlsx / md / json\nhtml where supported"]
     end
 
     ui --> sdk
@@ -102,8 +109,8 @@ graph TB
 
 | 平面 | 主要職責 | 不應承擔的責任 |
 |---|---|---|
-| **Copilot SDK control plane** | session/resume/persistence、tool policy hooks、custom agents、skills、operator UX、advisory audit、remediation planning、run summary | 正式 transport 執行、YAML semantics、最終 pass/fail 判定 |
-| **Deterministic verdict kernel** | case discovery/filtering、retry-aware timeout、plugin hook execution、structured evidence、report projection、final verdict | 自由對話式判讀、agent prompt orchestration |
+| **Copilot SDK control plane** | session/resume/persistence、tool policy hooks、custom agents、skills、operator UX、advisory audit、remediation planning、run summary | 正式 test semantics、正式 execution authority、最終 pass/fail 判定 |
+| **Deterministic verdict kernel** | case discovery/filtering、retry-aware timeout、plugin hook execution、structured evidence、report projection、canonical verdict lifecycle | 自由對話式判讀、agent prompt orchestration、domain-specific test meaning |
 
 ---
 
@@ -119,14 +126,14 @@ sequenceDiagram
     participant Evidence as Evidence Store
     participant CP as Copilot SDK Session
 
-    User->>CLI: run wifi_llapi / resume / ask summary
+    User->>CLI: run plugin / resume / ask summary
     CLI->>Orch: run(plugin, cases, policy)
     Orch->>Plugin: setup_env() / verify_env()
     Plugin->>Transport: execute(...)
-    Transport-->>Plugin: stdout/stderr/rc/elapsed
+    Transport-->>Plugin: output / status / timing
     Orch->>Plugin: execute_step() / evaluate()
     Orch->>Evidence: write selection trace + attempts + canonical result
-    Orch->>CLI: xlsx Pass/Fail + trace path
+    Orch->>CLI: report payload + trace path
 
     opt in-run environment recovery path
         Orch->>Plugin: tier-1 deterministic decision/executor
@@ -207,7 +214,7 @@ sequenceDiagram
 |---|---|---|
 | `pre_case` | case attempt 前置檢查 / remediation preflight | 不改 formal case semantics |
 | `post_case` | 收斂 advisory / remediation history / final annotations | 不覆寫 canonical evidence |
-| `pre_step` | step 前攔截與前置校驗 | 不直接代替 transport 執行正式測試 |
+| `pre_step` | step 前攔截與前置校驗 | 不直接代替 Plugin 的正式 test execution |
 | `post_step` | step 後觀測 / 附加結構化資料 | 不改正式 pass/fail 判定 |
 | `on_failure` | advisory / failure snapshot / remediation proposal | 不直接改 YAML、pass criteria、或最終 verdict |
 | `on_retry` | tier-1 execution / threshold 後 tier-2 one-shot | retry-only；catalog/schema/budget + forced `verify_env`，不碰 test semantics/verdict |
@@ -257,12 +264,13 @@ MCP 目前仍只作為 **selective extension surface**，優先順序低於 in-p
 ### 5.1 Kernel 仍保留的責任
 
 - case discovery / case filtering
-- source.row / object / api alignment gate
 - retry-aware timeout 與 fail-and-continue
 - plugin hook execution
-- transport binding
-- canonical result 寫入
-- xlsx / md/json report projection（另支援由 json opt-in 轉出 html）
+- run-backend / transport coordination on the core-owned path
+- canonical trace/result 寫入
+- generic report handoff / projection contracts
+
+Plugin-specific alignment gates（例如特定 source row、object、API mapping）應由各 Plugin 的 validation / prepare path 負責，不應被視為 Core 的通用 domain rule。
 
 ### 5.2 Canonical result
 
@@ -297,19 +305,21 @@ MCP 目前仍只作為 **selective extension surface**，優先順序低於 in-p
 
 | 輸出 | 內容 |
 |---|---|
-| `xlsx` | `Pass` / `Fail` only |
-| `md/json` | `comment` / `diagnostic_status` / `failure_snapshot` / `remediation_history` / timing / log line references；tier-2 固定契約目前在 per-case `agent_trace` 與 run payload |
-| `html` | 由既有 `json` opt-in 轉出的 self-contained diagnostic review artifact |
+| plugin reporter | 各 Plugin 可透過 `create_reporter()` 定義 domain-specific output |
+| core trace / payload | `comment` / `diagnostic_status` / `failure_snapshot` / `remediation_history` / timing / trace references |
+| core agent artifacts | tier-2 audit、agent usage、run analysis（僅支援的 core-owned path） |
+
+既有 field plugins 可能輸出 xlsx / md / json / html；這些格式與版型不是所有 Plugin 都必須提供的通用 Core 契約。
 
 ### 5.4 不可退讓的 kernel 邊界
 
 下列責任不得交給 conversational agent 決定：
 
-- YAML case semantics
+- formal case semantics
 - environment gate semantics
-- transport command execution
-- pass criteria comparison
-- xlsx final verdict projection
+-正式 test execution 的 authority
+- pass criteria comparison / plugin evaluation semantics
+- canonical final verdict
 - 任何越過 tier-1 allowlist 或 tier-2 capability/execution boundary 的動作，尤其修改 YAML、skip case、改 pass criteria 或 verdict
 
 ---
@@ -319,39 +329,42 @@ MCP 目前仍只作為 **selective extension surface**，優先順序低於 in-p
 | Artifact | 目的 | 備註 |
 |---|---|---|
 | `agent-config.yaml` | runner/model order、execution policy、tier-1/tier-2 governance budgets | 不得存放 provider secrets |
-| selection trace | 記錄模型選擇與 fallback | 必須持久化 |
+| selection trace | 記錄模型選擇與 fallback | core-owned path 持久化 |
 | attempt trace | 記錄 timeout / commands / outputs / comments | 每次 retry 都保留 |
-| canonical result | 報表投影與 agent summary 的共同來源 | 不可被 agent 任意覆寫 |
-| xlsx report | 對外交付 | Pass/Fail only |
-| md/json/html report | 內部診斷 / remediation / summary | 三種格式由 wifi_llapi run 自動 emit；`html` 同時可透過 `wifi-llapi json-to-html` post-process |
+| canonical result | 報表與後續 analysis 的共同來源 | 不可被 agent 任意覆寫 |
+| plugin reports | domain-specific deliverables | 格式與內容由 Plugin reporter 定義 |
+| core agent artifacts | agent usage / run analysis / tier-2 audit | optional control-plane artifacts，不構成 verdict authority |
 
 ---
 
 ## 7. 文件與目錄對照
 
 ```text
-testpilot/
+testpilot-core/
 ├── README.md
 ├── AGENTS.md
+├── VERSION
+├── pyproject.toml
 ├── docs/
 │   ├── plan.md
 │   ├── spec.md
 │   ├── todos.md
-│   └── （local-only research notes; not versioned）
+│   └── plugin-dev-guide.md
 ├── src/testpilot/
-│   ├── core/
-│   ├── reporting/
-│   ├── schema/
-│   ├── transport/
-│   └── env/
+│   ├── api/          # public Plugin SDK
+│   ├── core/         # orchestration / lifecycle / recovery
+│   ├── reporting/    # generic reporting contracts/helpers
+│   ├── schema/       # generic case schema helpers
+│   ├── transport/    # transport abstractions
+│   └── runtime/      # run-backend abstraction
 ├── plugins/
-│   └── wifi_llapi/
-│       ├── plugin.py
-│       ├── agent-config.yaml
-│       ├── cases/
-│       └── reports/
+│   └── _template/    # Plugin scaffold; not a domain test suite
+├── examples/
+│   └── sample_echo/  # runnable zero-hardware reference Plugin
 └── tests/
 ```
+
+Domain Plugins 可位於獨立 repository / distribution，透過 `testpilot.plugins` entry point 註冊；Core source 不應具名依賴特定 Plugin。
 
 ---
 
@@ -373,7 +386,7 @@ testpilot/
 ### 8.2 R5：Deterministic kernel 補強
 
 - plugin fallback heuristic 收斂
-- session/device binding 更嚴格
+- session/device binding 更嚴格（device-oriented reference path）
 - canonical result / report projector 完整化
 - control-plane / verdict-plane 邊界測試
 - orchestrator / plugin 結構瘦身與解耦
@@ -384,24 +397,27 @@ testpilot/
 
 ### 9.1 已知風險
 
-- `Orchestrator` 仍是責任過重的中心點
-- `wifi_llapi/plugin.py` 仍含 wording-sensitive fallback path
-- core tier-2 framework 已落地，但實體 plugin 的 capability/executor opt-in 仍須各 plugin 自行完成與驗證
-- Copilot SDK 仍屬 technical preview，導入時需分階段落地
+- `Orchestrator` 仍是責任較重的中心點
+- managed installer / field configuration 仍反映目前 maintainer 的 device-testing stack，尚未等同於通用 Plugin distribution service
+- core tier-2 contract 已落地，但各實體 Plugin 的 capability/executor opt-in 仍須自行完成與驗證
+- custom runner 可繞過部分 core-owned analysis path，文件與 Plugin author 需清楚區分 execution ownership
+- Copilot SDK integration 仍應視為 optional control-plane capability，而不是 deterministic test path 的必要條件
 
 ### 9.2 非目標
 
 - 不把 YAML 當作主要 execution prompt
 - 不讓 agent 直接決定最終 pass/fail
-- 不用 generic MCP shell 取代正式 transport
-- 不為舊 `codex CLI` policy 新增 workaround code
+- 不用 generic MCP shell 取代正式 Plugin / transport execution
+- 不宣稱任意 domain 不需 Plugin integration 即可開箱執行
+- 不把目前的 TestPilot Core 描述成具備集中式資源管理、registry、dashboard 等能力的完整 test platform
 
 ---
 
 ## 10. 參考文件
 
-1. `docs/plan.md`：主計畫與 phase 邊界
-2. `docs/todos.md`：唯一待辦看板
-3. 本文件與 `docs/plan.md`：第三次重構的 repo 內收斂基線
-4. `README.md`：對外說明與當前/目標方向摘要
-5. `AGENTS.md`：專案級 agent/model/policy 規則
+1. `README.md`：對外定位、目前支援方式與安裝說明
+2. `docs/plugin-dev-guide.md`：Plugin SDK 開發契約
+3. `docs/plan.md`：第三次重構主計畫與 phase 邊界
+4. `docs/todos.md`：repo 待辦看板
+5. 本文件：第三次重構設計基線與 current-state 邊界註記
+6. `AGENTS.md`：專案級 agent/model/policy 規則

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -317,7 +317,7 @@ Plugin-specific alignment gates（例如特定 source row、object、API mapping
 
 - formal case semantics
 - environment gate semantics
--正式 test execution 的 authority
+- 正式 test execution 的 authority
 - pass criteria comparison / plugin evaluation semantics
 - canonical final verdict
 - 任何越過 tier-1 allowlist 或 tier-2 capability/execution boundary 的動作，尤其修改 YAML、skip case、改 pass criteria 或 verdict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "testpilot-core"
 dynamic = ["version"]
-description = "Plugin-based test automation framework for embedded device verification"
+description = "Plugin-based test automation and verification framework"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"

--- a/src/testpilot/__init__.py
+++ b/src/testpilot/__init__.py
@@ -1,3 +1,3 @@
-"""TestPilot — plugin-based test automation for embedded devices."""
+"""TestPilot — plugin-based test automation and verification framework."""
 
 __version__ = "0.3.7"

--- a/src/testpilot/cli.py
+++ b/src/testpilot/cli.py
@@ -826,7 +826,7 @@ def _wheel_cache_path() -> Path:
     ``scripts/install.sh`` preserves the wheels it installs here so that the
     ``testpilot --update`` rollback can reinstall the last-good set with
     ``--no-index`` / ``--find-links`` — it must NEVER reach a public index
-    (dependency-confusion hazard for the private ``testpilot-core``/plugins).
+    (dependency-confusion hazard for private plugin distributions).
     """
     return _get_managed_venv().parent / ".wheel-cache"
 
@@ -1289,7 +1289,7 @@ def main(
     update_ref: str | None,
     verify_install: bool,
 ) -> None:
-    """TestPilot — plugin-based test automation for embedded devices.
+    """TestPilot — plugin-based test automation and verification framework.
 
     \b
     A plugin can be selected two ways:

--- a/src/testpilot/core/plugin_base.py
+++ b/src/testpilot/core/plugin_base.py
@@ -16,14 +16,14 @@ class IncompatiblePluginError(Exception):
 
 
 class PluginBase(ABC):
-    """各測試類型 plugin 繼承此基底類別。
+    """Base contract implemented by TestPilot plugins.
 
-    Plugin 負責：
-    1. 發現並載入 cases/*.yaml
-    2. 依 case 描述佈建測試環境
-    3. 執行測試步驟
-    4. 評估通過條件
-    5. 清理環境
+    A plugin owns project-specific test semantics:
+    1. discover and load test cases
+    2. prepare and verify the test environment
+    3. execute test steps
+    4. evaluate domain-specific pass/fail conditions
+    5. clean up project-owned resources
     """
 
     api_version: str | None = None
@@ -53,7 +53,7 @@ class PluginBase(ABC):
         """掃描 cases/ 目錄，回傳所有 test case 描述（已解析的 YAML dict）。"""
 
     def setup_env(self, case: dict[str, Any], topology: Any) -> bool:
-        """依 case 描述佈建測試環境（DUT/STA/EndpointPC）。
+        """Prepare the environment required by this test case.
 
         預設實作直接回傳 True（不需佈建）。子類別可覆寫。
 
@@ -63,7 +63,7 @@ class PluginBase(ABC):
         return True
 
     def verify_env(self, case: dict[str, Any], topology: Any) -> bool:
-        """環境自檢：驗證連線、服務就緒。
+        """環境自檢：驗證測試所需的前置條件是否就緒。
 
         預設實作直接回傳 True（不需驗證）。子類別可覆寫。
 


### PR DESCRIPTION
## Superseded

This PR used a `docs/*` source branch, but this repository's R-12 policy requires PRs targeting `main` to originate from `feature/*`. The content is preserved and re-opened from a policy-compliant branch.

No content from this PR was merged.
