### PR TITLE
chore(policy): 同步 project policy 1.0.15 → 1.0.17

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.15 管轄。
+本 repo 受 hamanpaul project policy v1.0.17 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.15`
+- policy_version: `1.0.17`
 
 ## 動工前
 - [ ] 確認當前分支不是 `main`
@@ -85,7 +85,7 @@ review 變更時，除了 R-22 抓得到的懸空引用，另留意**語意陳�
 
 # TestPilot Development Guidelines
 
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 ## Scope
 

--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   external-policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab # v1.0.15
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7 # v1.0.17
     with:
       policy_profile: flat
-      policy_version: "1.0.15"
-      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
+      policy_version: "1.0.17"
+      policy_engine_ref: 9e7fabbf0b5eea9ad933fa6798764b723934a0b7
 
   release-governance:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   project-policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab # v1.0.15
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7 # v1.0.17
     with:
       policy_profile: flat
-      policy_version: "1.0.15"
-      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
+      policy_version: "1.0.17"
+      policy_engine_ref: 9e7fabbf0b5eea9ad933fa6798764b723934a0b7
 
   publish:
     runs-on: ubuntu-latest

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,7 +1,7 @@
 version: 1
 project: testpilot
 policy_profile: flat
-policy_version: "1.0.15"
+policy_version: "1.0.17"
 preflight:
   steps:
     # 註：openspec gate 暫不宣告——本 repo 現有 4 個 spec（audit-mode、
@@ -43,4 +43,4 @@ policy_check:
   repository: hamanpaul/paulsha-conventions
   config: .project-policy.yml
   pin_required: true
-  workflow_ref: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab
+  workflow_ref: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.15 管轄。
+本 repo 受 hamanpaul project policy v1.0.17 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.15`
+- policy_version: `1.0.17`
 
 ## 動工前
 - [ ] 確認當前分支不是 `main`
@@ -85,7 +85,7 @@ review 變更時，除了 R-22 抓得到的懸空引用，另留意**語意陳�
 
 # TestPilot Development Guidelines
 
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 ## Scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.15 管轄。
+本 repo 受 hamanpaul project policy v1.0.17 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.15`
+- policy_version: `1.0.17`
 
 ## 動工前
 - [ ] 確認當前分支不是 `main`
@@ -85,7 +85,7 @@ review 變更時，除了 R-22 抓得到的懸空引用，另留意**語意陳�
 
 # TestPilot Development Guidelines
 
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 ## Scope
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.15 管轄。
+本 repo 受 hamanpaul project policy v1.0.17 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.15`
+- policy_version: `1.0.17`
 
 ## 動工前
 - [ ] 確認當前分支不是 `main`
@@ -85,7 +85,7 @@ review 變更時，除了 R-22 抓得到的懸空引用，另留意**語意陳�
 
 # TestPilot Development Guidelines
 
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 ## Scope
 

--- a/changelog.d/policy-1-0-17-upgrade.md
+++ b/changelog.d/policy-1-0-17-upgrade.md
@@ -1,0 +1,17 @@
+---
+type: change
+scope: policy
+---
+同步 hamanpaul project policy 1.0.15 → 1.0.17。
+
+- `policy_version` 1.0.15 → 1.0.17（`.project-policy.yml` 與四份 agent convention 檔）。
+- `workflow_ref` / `policy_engine_ref` 雙 pin 換為 v1.0.17 的
+  `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`（`policy-check.yml` 與 `release.yml` 兩支，
+  `uses:` 尾註 `# v1.0.17`）。
+- `tests/test_release_governance.py` 中寫死的 policy_version / managed-by 斷言同步更新。
+
+1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，僅上游引擎自身的 distribution
+identity、runtime bundle 與 release workflow 修正，故本次為純版本同步。1.0.16 引入
+的引擎版本 gate（執行中引擎版本與 repo 宣告的 `policy_version` 不符即 fail-loud）
+是本次同步的實益：pin SHA 與 `policy_version` 已同 PR 原子更新，本機
+`policy_check` 預檢可與 CI 判定一致。

--- a/tests/test_release_governance.py
+++ b/tests/test_release_governance.py
@@ -49,7 +49,7 @@ def test_project_policy_declares_help_sync_markers() -> None:
 
     policy = _read_policy()
     assert policy["policy_profile"] == "flat"
-    assert policy["policy_version"] == "1.0.15"
+    assert policy["policy_version"] == "1.0.17"
     markers = {entry["marker"] for entry in policy["cli"]}
 
     assert {
@@ -77,8 +77,8 @@ def test_agent_instruction_files_are_synchronized() -> None:
         assert contents[relative_path] == reference
 
     content = reference.decode("utf-8")
-    assert "<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->" in content
-    assert "policy_version: 1.0.15" in content
+    assert "<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->" in content
+    assert "policy_version: 1.0.17" in content
     # 同步 payload 不得引用已退役的 .paul-project.yml(本 repo canonical 是 .project-policy.yml;
     # codex review #90)——否則 agent 會看/建錯 config。
     assert ".paul-project.yml" not in content, (


### PR DESCRIPTION
Closes #44

## 變更

上游 hamanpaul/paulsha-conventions 已發布 v1.0.17。1.0.16 引入的引擎版本 gate 會在執行中引擎與 repo 宣告的 `policy_version` 不符時 fail-loud，因此 pin SHA 與 `policy_version` 必須**同 PR 原子更新**。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，本次為純版本同步：

- `.project-policy.yml` `policy_version` 1.0.15 → 1.0.17，`workflow_ref` SHA 同步
- `Policy Check`（`policy-check.yml`）與 `Publish Release`（`release.yml`）**兩支** workflow：`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`（尾註 `# v1.0.17`）
- 四份 agent convention 檔（`CLAUDE.md`／`AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md`；本 repo非 symlink 模式，四份獨立檔案，已同步並保持內容一致）版本引用同步
- `tests/test_release_governance.py` 中寫死的 `policy_version` / `managed-by` 字串斷言同步更新（否則測試會對舊版本斷言直接失敗）
- 新增 changelog fragment：`changelog.d/policy-1-0-17-upgrade.md`（照本 repo `docs/release-flow.md` 慣例，一般 PR 不直接改 `CHANGELOG.md`，release 準備時才 collate）

## 驗證

- 本機以 v1.0.17 引擎 `python3 -m policy_check --repo .`：**EXIT=0**，pass 24 / fail 0 / warn 2（R-21 marker、R-22 92 個 pre-existing dangling doc reference，皆為既有 advisory、非本次引入）。
- `pytest -q tests`：**735 passed, 1 skipped**，僅 1 個既有、與本次無關的 cp311 環境限定失敗（`test_installer.py::TestOfflineInstall::test_offline_creates_wrapper`，本機 Python 3.12 而 bundle 要求 `cp311`；未修改的 `main` 上同樣失敗，CI 為綠）。
- CI `Policy Check` + `CI` workflow：待這支 PR 觸發後確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
